### PR TITLE
Introduce configurable parameters for minimum rows and columns in table detection

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -329,6 +329,8 @@ def to_markdown(
     show_progress=False,
     use_glyphs=False,
     ignore_alpha=False,
+    min_table_rows=2,
+    min_table_cols=2,
 ) -> str:
     """Process the document and return the text of the selected pages.
 
@@ -354,6 +356,8 @@ def to_markdown(
         show_progress: (bool, False) print progress as each page is processed.
         use_glyphs: (bool, False) replace the Invalid Unicode by glyph numbers.
         ignore_alpha: (bool, True) ignore text with alpha = 0 (transparent).
+        min_table_rows: (int, 2) minimum number of rows for a table to be included.
+        min_table_cols: (int, 2) minimum number of columns for a table to be included.
 
     """
     if write_images is False and embed_images is False and force_text is False:
@@ -929,7 +933,7 @@ def to_markdown(
         return nwords
 
     def get_page_output(
-        doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS
+        doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS, min_table_rows, min_table_cols
     ):
         """Process one page.
 
@@ -1036,7 +1040,7 @@ def to_markdown(
             tabs = page.find_tables(clip=parms.clip, strategy=table_strategy)
             for t in tabs.tables:
                 # remove tables with too few rows or columns
-                if t.row_count < 2 or t.col_count < 2:
+                if t.row_count < min_table_rows or t.col_count < min_table_cols:
                     omitted_table_rects.append(pymupdf.Rect(t.bbox))
                     continue
                 parms.tabs.append(t)
@@ -1200,7 +1204,7 @@ def to_markdown(
         pages = ProgressBar(pages)
     for pno in pages:
         parms = get_page_output(
-            doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS
+            doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS, min_table_rows, min_table_cols
         )
         if page_chunks is False:
             document_output += parms.md_string

--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -360,6 +360,12 @@ def to_markdown(
         min_table_cols: (int, 2) minimum number of columns for a table to be included.
 
     """
+    # Validate min_table_rows and min_table_cols parameters
+    if not isinstance(min_table_rows, int) or min_table_rows < 1:
+        raise ValueError("min_table_rows must be a positive integer (>= 1)")
+    if not isinstance(min_table_cols, int) or min_table_cols < 1:
+        raise ValueError("min_table_cols must be a positive integer (>= 1)")
+
     if write_images is False and embed_images is False and force_text is False:
         raise ValueError("Image and text on images cannot both be suppressed.")
     if embed_images is True:


### PR DESCRIPTION
**Description**
This PR introduces two new parameters to control table detection during Markdown output:

* `min_table_rows`: Minimum number of rows required for a table to be included
* `min_table_cols`: Minimum number of columns required for a table to be included

Both parameters include basic validation to prevent invalid values.

---

**Motivation / Background**
In the current implementation, tables with fewer than 2 rows are automatically excluded. While this works for most cases, real-world PDFs sometimes contain edge cases where a single-row table should still be recognized:

* When the last row of a table is split onto the next page
* When a separator line appears immediately after the header, resulting in only one detected row

In these situations, treating all single-row tables as invalid leads to loss of useful information. By making the minimum rows and columns configurable, users gain flexibility to adapt table detection to their specific document structures.

---

**Changes**

* Added parameters `min_table_rows` and `min_table_cols`
* Added validation for parameter values
* Updated table filtering logic to use configurable thresholds

---

**Notes**
This change preserves the current default behavior (`min_table_rows = 2`, `min_table_cols = 2`) to avoid breaking existing usage, while allowing users to override when needed.
