### PR TITLE
TocHeaders: strip byte order mark

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -207,6 +207,7 @@ class TocHeaders:
         for t in my_toc:
             title = t[1].strip()  # title of TOC entry
             title = title.lstrip("\ufeff")  # remove byte order mark if any
+            title = title.replace("\xa0", " ")  # replace non-breaking spaces
             lvl = t[0]  # level of TOC entry
             if text.startswith(title) or title.startswith(text):
                 # found a match: return the header tag

--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -206,6 +206,7 @@ class TocHeaders:
         text = span["text"].strip()  # remove leading and trailing whitespace
         for t in my_toc:
             title = t[1].strip()  # title of TOC entry
+            title = title.lstrip("\ufeff")  # remove byte order mark if any
             lvl = t[0]  # level of TOC entry
             if text.startswith(title) or title.startswith(text):
                 # found a match: return the header tag


### PR DESCRIPTION
A quick fix for #308.

Alternatively, do you think this is an upstream bug and the BOM should not have been extracted in the first place?

Best,
Paul