### PR TITLE
Address tabulate issue

### DIFF
--- a/src/helpers/document_layout.py
+++ b/src/helpers/document_layout.py
@@ -378,7 +378,7 @@ def fallback_text_to_text(textlines, ignore_code: bool = False, clip=None):
         else:
             i = 0
         for j, s in enumerate(spans, start=i):
-            line[j] = s["text"].strip()
+            line[j] = s["text"].strip() + " "
         lines.append(line)
     tab_text = tabulate.tabulate(
         lines,


### PR DESCRIPTION
The error introduced in v 0.10.0 of tabulate can only be circumvented by forcing the content of all cells to be strings. That comes at the cost of an additional space appended to the cell text. This is harmless - and will be omitted by the final table grid rendering.