### PR TITLE
Corrects boolean check for ignore_alpha variable.

### DIFF
--- a/src/helpers/pymupdf_rag.py
+++ b/src/helpers/pymupdf_rag.py
@@ -974,7 +974,7 @@ def to_markdown(
         parms.words = []
         parms.line_rects = []
         parms.accept_invisible = (
-            page_is_ocr(page) or ignore_alpha
+            page_is_ocr(page) or ignore_alpha is False
         )  # accept invisible text
 
         # determine background color


### PR DESCRIPTION
In `pymupdf_rag.py` - we have the  `ignore_alpha` variable defined as follows:

`ignore_alpha: (bool, True) ignore text with alpha = 0 (transparent).`

But then later:

```
parms.accept_invisible = (
            page_is_ocr(page) or ignore_alpha
        )  # accept invisible text
```

I think the logic here is to check if `ignore_alpha` is `False` is correct.