### PR TITLE
Fix: small glyph line grouping issue

### DIFF
--- a/src/helpers/get_text_lines.py
+++ b/src/helpers/get_text_lines.py
@@ -172,8 +172,14 @@ def get_raw_lines(
     for s in spans[1:]:  # walk through the spans
         sbbox = s["bbox"]  # this bbox
         sbbox0 = line[-1]["bbox"]  # previous bbox
-        # if any of top or bottom coordinates are close enough, join...
-        if abs(sbbox.y1 - sbbox0.y1) <= y_delta or abs(sbbox.y0 - sbbox0.y0) <= y_delta:
+        # Same line if top OR bottom edges align, OR the previous bbox is
+        # vertically contained in the current one. Handles tiny glyphs like
+        # "-", ".", "*" sitting centered within full-height text.
+        if (
+            abs(sbbox.y1 - sbbox0.y1) <= y_delta
+            or abs(sbbox.y0 - sbbox0.y0) <= y_delta
+            or (sbbox0.y0 >= sbbox.y0 - y_delta and sbbox0.y1 <= sbbox.y1 + y_delta)
+        ):
             line.append(s)  # append to this line
             lrect |= sbbox  # extend line rectangle
             continue

--- a/tests/test_370.py
+++ b/tests/test_370.py
@@ -74,7 +74,3 @@ def test_370_small_glyph_line_assignment():
         'Buggy output detected: dash was moved to the start of the '
         'paragraph and detached from "g".'
     )
-
-if __name__ == "__main__":
-    #test_370()
-    test_370_small_glyph_line_assignment()

--- a/tests/test_370.py
+++ b/tests/test_370.py
@@ -43,3 +43,38 @@ def test_370():
     # Disable this assert for now because we don't appear to get consistent
     # output on different OS's.
     #assert actual == expected
+
+
+def test_370_small_glyph_line_assignment():
+    # Regression test: tiny glyphs (e.g. "-") with accurate bboxes that sit
+    # vertically centered inside full-height text were being split off onto
+    # their own line. In test_370.pdf this caused the dash in
+    # "g- silylallyloxysilane" to be moved to the start of the paragraph,
+    # producing "- To demonstrate ... g silylallyloxysilane".
+    path = os.path.normpath(f'{__file__}/../../tests/test_370.pdf')
+
+    with pymupdf.open(path) as document:
+        actual = pymupdf4llm.to_markdown(
+                document,
+                write_images=False,
+                embed_images=False,
+                image_format="jpg",
+                header=False,
+                footer=False,
+                show_progress=False,
+                force_text=True,
+                page_separators=True,
+                )
+
+    assert "g- silylallyloxysilane" in actual, (
+        'Expected dash to stay attached to "g-" on the same line as '
+        '"silylallyloxysilane".'
+    )
+    assert "- To demonstrate the feasibility of our strategy, g silylallyloxysilane" not in actual, (
+        'Buggy output detected: dash was moved to the start of the '
+        'paragraph and detached from "g".'
+    )
+
+if __name__ == "__main__":
+    #test_370()
+    test_370_small_glyph_line_assignment()


### PR DESCRIPTION
### Description
In `helpers/get_text_lines.py::get_raw_lines`, spans are grouped into lines by checking whether their top or bottom y-coordinate aligns within `tolerance` (default 3). This fails for glyphs that have a small, accurate bbox sitting vertically centered inside the full-height text, like a dash, period, or asterisk. Neither edge of the small bbox aligns with the surrounding text, so the glyph gets treated as a different line and ends up reordered.

The issue occurs with `tests/test_370.pdf`.

Expected:
> To demonstrate the feasibility of our strategy, g- silylallyloxysilane **1a** was treated...

Actual (before this PR):
> - To demonstrate the feasibility of our strategy, g silylallyloxysilane **1a** was treated...

The dash gets pulled off `g-` and stuck at the start of the paragraph.

### Fix
Added a containment check alongside the existing edge-alignment checks: if the previous span's vertical extent fits inside the current span's (within `tolerance`), they belong on the same line. 

### Test
Added `test_370_small_glyph_line_assignment` in `tests/test_370.py`, which asserts the dash stays attached to `g-` and does not get reordered to the start of the paragraph.
