### PR TITLE
Add layout-aware chunking: opt-in to_chunks() API

### DIFF
--- a/CHUNKING.md
+++ b/CHUNKING.md
@@ -9,37 +9,44 @@ section hierarchy, and ingestion diagnostics.
 Chunk text is the **same markdown** `to_markdown()` emits for the same
 boxes (rendered through the same renderers), so chunks never carry glued
 words the renderer would have spaced correctly — a direct hit on
-sparse/BM25 recall: a term glued to its neighbor is a term your keyword
-index cannot match.
+keyword-search recall (BM25 and similar): a term glued to its neighbor
+is a term your keyword index cannot match.
+
+Every Python block in this document runs as-is from the repository root
+against PDFs shipped with the repository; `tests/test_chunking_docs.py`
+executes them in order.
 
 ## Quick Start
 
 ```python
 import pymupdf4llm
 
-cd = pymupdf4llm.to_chunks("input.pdf")
+cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf")
 
 for c in cd:
-    print(c.id, c.metadata.chunk_type, c.text[:80])
+    print(c.id, c.metadata.types, c.text.splitlines()[0])
+# -> c0 ['heading', 'paragraph', 'table'] # **World Capital Cities**
+#    c1 ['table'] |**Country**|**Capital**|**Population**|**%**|**Year**|
+#    ...
 ```
 
 ## Two Ways to Call
 
 ```python
 # 1. One-step: file path or pymupdf.Document
-cd = pymupdf4llm.to_chunks("input.pdf", max_tokens=400)
+cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf",
+                           max_tokens=400)
 
 # 2. Two-step: parse first, then chunk
 from pymupdf4llm.helpers.document_layout import parse_document
 
-doc = parse_document("input.pdf")
+doc = parse_document("examples/country-capitals/national-capitals.pdf")
 cd = doc.to_chunks(max_tokens=400)
 ```
 
 The one-step form accepts both parse and chunk parameters; they are split
 internally by the `parse_document` signature. Unknown chunking parameters
-raise `TypeError`. (`to_chunk()` still works but emits a
-`DeprecationWarning`.)
+raise `TypeError`.
 
 ## At a Glance
 
@@ -62,6 +69,23 @@ The two parameter tiers below map onto the two arrows: parse parameters
 change the substrate (re-parse required), chunk parameters only change
 assembly (`reassemble_chunks()` is enough).
 
+Assembly itself works in stages. Layout signals (box boundaries, box
+classes, font changes, vertical gaps, page breaks) first propose cut
+points; the resulting chunks are then refined in three passes:
+
+1. **Split**: break oversized chunks at sentence boundaries.
+2. **Semantic merge**: rejoin a heading with the content that follows it,
+   and a caption with its figure or table.
+3. **Budget merge**: greedily combine neighbouring chunks while the result
+   stays within `max_tokens`. A section-opening chunk never merges
+   backward into the previous section (`respect_section_starts=True`).
+
+The semantic merge is what keeps a heading from being stranded at the end
+of one chunk with its paragraph in the next, and a caption from being
+separated from its figure or table. These are internal stages of
+`to_chunks()` and `reassemble_chunks()`, not public methods; the chunk
+parameters below are how you steer them.
+
 ## Parameters
 
 ### Parse Parameters
@@ -76,7 +100,7 @@ Passed to `parse_document()` internally.
 | `use_ocr` | (select) | OCR mode |
 | `force_ocr` | `False` | Force OCR on all pages |
 | `ocr_language` | `"eng"` | OCR language |
-| `table_output` | `"markdown"` | `"html"` opts into the engine HTML table model (like `to_markdown`); needs a PyMuPDF with the layout-union table model, degrades to markdown tables with a warning otherwise. Changes `TableChunk` content per D15 (see Views) and re-splits boxes (see IDs) |
+| `table_output` | `"markdown"` | `"html"` opts into the engine HTML table model (like `to_markdown`); needs a PyMuPDF with the layout-union table model, degrades to markdown tables with a warning otherwise. Changes `TableChunk` content (see Views) and re-splits boxes (see IDs) |
 | `edge_threshold` | `None` | Layout GNN edge-probability cut for box grouping (engine default 0.55; lower merges more, higher fragments more) |
 | `show_progress` | `False` | Show progress bar |
 
@@ -87,7 +111,7 @@ rejects them — re-parse via `to_chunks()` to change them.
 
 | Parameter | Default | Description |
 |---|---|---|
-| `max_tokens` | `400` | Maximum tokens per chunk. The default targets embedding-model inputs; larger budgets (800–2000) suit long-context synthesis, rerankers, and section-first keyword retrieval — see recipes 7–9 |
+| `max_tokens` | `400` | Maximum tokens per chunk. The default targets embedding-model inputs; larger budgets (800–2000) suit long-context synthesis, rerankers, and section-first keyword retrieval — see recipes 5 and 6 |
 | `min_tokens` | `120` | Minimum tokens (merge threshold) |
 | `breakpoint_threshold` | `0.5` | Boundary score threshold for splitting |
 | `merge_small_chunks` | `True` | Merge undersized chunks with neighbors |
@@ -98,9 +122,9 @@ rejects them — re-parse via `to_chunks()` to change them.
 | `tokenizer` | `None` | tiktoken encoding name (unknown names raise `ValueError`), a `callable(text) -> int`, or `None` (character estimate) |
 | `weights` | `None` | Boundary-score weight overrides |
 
-`to_chunks()` no longer takes `output_format` or `include_contextual_text`;
-`ChunkedDocument.to_dicts()` / `.to_json()` take a keyword-only
-`include_contextual` (default `True`) instead.
+Whether `contextual_text` is included in exports is decided at export
+time: `ChunkedDocument.to_dicts()` / `.to_json()` take a keyword-only
+`include_contextual` (default `True`).
 
 ### Choosing a budget
 
@@ -116,7 +140,7 @@ exact number (structure-based splitting beats size tuning in 2025–26
 studies), and on layout-rich documents only ~10–40% of chunks hit the
 budget cap at all — the rest end at headings, tables, and boxes. When a
 different consumer needs a different size, `reassemble_chunks()` is the intended
-answer (recipes 7–9), not a changed default.
+answer (recipes 5 and 6), not a changed default.
 
 ## IDs Are a Contract
 
@@ -135,47 +159,75 @@ version, parse options)*. Parse modes that re-split boxes (e.g. HTML
 table rendering) change box indices — never cache ids across parse-option
 changes.
 
+**Chunk ids are positions.** `c{n}` is the n-th chunk in reading order, so
+`cd.get("c3") is cd[3]`. They are local to one `ChunkedDocument`: a
+`reassemble_chunks()` result numbers its own chunks from `c0` again.
+Table, figure, section and element ids do not depend on the budget.
+
 `cd.get(id)` resolves any of these; raises `KeyError` for an unknown id
 unless you pass `default=`.
 
 ## ChunkedDocument
 
-```python
-cd = pymupdf4llm.to_chunks("input.pdf")
+`to_chunks()` returns a `ChunkedDocument`. It is a `Sequence[Chunk]` in
+reading order with the document structure attached:
 
-len(cd), cd[0], cd[2:5]        # Sequence[Chunk]
-cd.chunks                      # chunks as a tuple (== tuple(cd))
-cd.text                        # lazy full text (chunks joined)
-cd.elements                    # every layout box, header/footer included
-cd.tables, cd.figures, cd.sections   # views, linked to chunks both ways
+```python
+cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf")
+
+# Chunks: a sequence in reading order
+len(cd)                        # 6
+cd[0], cd[2:5]                 # a Chunk, a list of Chunks
+cd.index(cd[3])                # 3 (Sequence protocol: iteration, slicing, index)
+cd.chunks                      # the same chunks as a tuple
+cd.text                        # all chunk text joined (lazy)
+
+# Structure
+cd.elements                    # every layout box, header/footer included (Element)
+cd.tables                      # list[TableChunk]   (see Views)
+cd.figures                     # list[FigureChunk]
+cd.sections                    # list[SectionChunk]
 cd.hierarchy                   # sections as a SectionNode tree (root level 0)
-cd.diagnostics                 # ingestion-gate input (see recipe 2)
-cd.to_dicts(), cd.to_json()    # JSON-safe, content_hash included; include_contextual=True by default
+cd.get("c0")                   # any public id: c{n}, t{n}, f{n}, s{n}, p{page}.b{box}
+cd.get("t0"), cd.get("s0"), cd.get("p1.b0")
+cd.get("nope", default=None)   # KeyError without default=
+
+# Exports (JSON-safe; content_hash included)
+cd.to_dicts()                  # list[dict], schema below
+cd.to_json(indent=2)           # json.dumps(cd.to_dicts()); extra kwargs go to json.dumps
+cd.to_dicts(include_contextual=False)   # drop contextual_text from the payload
+# Framework exports need optional dependencies (recipe 7):
+#   cd.to_langchain_documents()   -> list[langchain_core.documents.Document]
+#   cd.to_llama_nodes()           -> list[llama_index.core.schema.TextNode]
+
+# Re-chunking, diagnostics, provenance
+cd.reassemble_chunks(max_tokens=200)   # new ChunkedDocument from retained units, no re-parse
+cd.diagnostics                 # dict for an ingestion gate (keys below)
+cd.params                      # read-only mapping of the parameters cd was built with
 cd.contextualize(cd[0])        # == cd[0].contextual_text
-cd.reassemble_chunks(max_tokens=200)     # cheap re-assembly from retained units
-cd.params                      # read-only mapping of the params used to build cd
 ```
 
 `reassemble_chunks()` accepts assembly-tier parameters only (`max_tokens`,
 `min_tokens`, `breakpoint_threshold`, `table_mode`, `merge_small_chunks`,
 `respect_section_starts`). Substrate parameters (`sentence_splitter`,
 `header_footer_mode`, `tokenizer`, `weights`) and parse options raise
-`ValueError` — call `to_chunks()` on a new parse instead.
+`ValueError` — call `to_chunks()` on a new parse instead. It returns a new
+`ChunkedDocument`; the original is unchanged.
 
 ### Chunk
 
-```python
+```text
 Chunk:
-    id: str                    # "c0", "c1", ... (chunk_id is a read-only alias)
+    id: str                    # "c0", "c1", ... (position in this ChunkedDocument)
     text: str                  # markdown, identical to to_markdown's rendering
-    contextual_text: str       # text with [Section], [Page], [Type] tags
+    contextual_text: str       # text with [Section], [Page], [Type] tags (format below)
     content_hash: str          # lazy sha256 of whitespace-normalized text
     metadata: ChunkMetadata
 ```
 
 ### ChunkMetadata
 
-```python
+```text
 ChunkMetadata:
     page_start, page_end: int  # 1-based original page numbers (survive pages=)
     element_ids: list[str]     # ["p1.b0", ...] — evidence addresses
@@ -183,8 +235,8 @@ ChunkMetadata:
     section_id: str | None     # innermost section ("s{n}")
     table_ids: list[str]       # tables in this chunk ("t{n}")
     figure_ids: list[str]      # figures in this chunk ("f{n}")
-    chunk_type: str            # "paragraph", "table", "list", "figure", ... (chunk_type_hint is a read-only alias)
-    chunk_types: list[str]     # all types present
+    types: list[str]           # element types present, in order:
+                               # "heading", "paragraph", "table", "list", "figure", "caption", ...
     bboxes: list[tuple]        # (page, x0, y0, x1, y1)
     lists: list[dict]          # logical list groups
     token_count: int           # per-chunk token count
@@ -192,10 +244,56 @@ ChunkMetadata:
     file_path, page_count
 ```
 
+### to_dicts() schema
+
+One dict per chunk; `metadata` carries every `ChunkMetadata` field as-is:
+
+```text
+{
+    "id": "c0",
+    "text": "...",
+    "content_hash": "6adc89bf...",
+    "contextual_text": "...",          # omitted with include_contextual=False
+    "metadata": {
+        "page_start": 1, "page_end": 1, "bboxes": [...],
+        "types": ["heading", "paragraph", "table"],
+        "section_id": "s0", "section_path": ["World Capital Cities"],
+        "token_count": 351, "element_ids": ["p1.b0", "p1.b1", "p1.b2"],
+        "table_ids": ["t0"], "figure_ids": [], "lists": [], "ocr": false,
+        "file_path": "...", "page_count": 6
+    }
+}
+```
+
+### diagnostics
+
+`cd.diagnostics` reports facts about the parse for an ingestion gate; your
+pipeline owns the thresholds (recipe 2). Values shown are for the example
+document:
+
+```text
+{
+    "chunk_count": 6, "element_count": 14, "table_count": 6, "figure_count": 0,
+    "section_count": 1, "page_count": 6,
+    "pages_without_chunks": [],      # 1-based pages no chunk covers
+    "zero_chunk_causes": [],         # only when chunk_count == 0: "no_text_extracted",
+                                     # "all_units_header_footer" or "all_units_filtered"
+    "figures_without_text": [],      # figure ids with no extractable text (OCR candidates)
+    "degenerate_tables": [],         # table ids whose rendering is empty
+    "header_footer_excluded": 6      # units dropped by header_footer_mode
+}
+```
+
 ### Views
 
-```python
-TableChunk:   id, chunk_id, element_id, page, bbox,
+`cd.tables`, `cd.figures` and `cd.sections` are lists of these objects;
+each links back to the chunk that holds it (`chunk_id`), and the chunk
+links forward via `metadata.table_ids` / `figure_ids` / `section_id`:
+
+```text
+TableChunk:   id                # "t{n}"
+              chunk_id          # id of the chunk holding this table ("c{n}")
+              element_id, page, bbox
               markdown | html   # mutually exclusive by parse mode
               headers           # header cell texts from <th>; [] on markdown parses
               caption, caption_element_id
@@ -203,7 +301,9 @@ TableChunk:   id, chunk_id, element_id, page, bbox,
               token_count
               text              # canonical rendering for the parse mode
 
-FigureChunk:  id, chunk_id, element_id, page, bbox, boxclass,
+FigureChunk:  id                # "f{n}"
+              chunk_id          # id of the chunk holding this figure
+              element_id, page, bbox, boxclass
               ocr_text          # extracted text; None → OCR candidate
               placeholder       # "[Figure f{n}: WxH]" when there's no text
               caption, caption_element_id
@@ -211,11 +311,12 @@ FigureChunk:  id, chunk_id, element_id, page, bbox, boxclass,
               image             # bytes when extract_images=True
               has_text          # bool(ocr_text and ocr_text.strip())
 
-SectionChunk: id, title, level, page_start, page_end,
+SectionChunk: id                # "s{n}"
+              title, level, page_start, page_end
               heading_element_id
               path              # titles, root → self
               element_span      # [start, end) into ChunkedDocument.elements
-              child_chunk_ids   # chunks under this section
+              child_chunk_ids   # chunks under this section, subtree included
               token_count       # sum over child chunks
               text              # lazy, assembled from the element registry
 ```
@@ -238,263 +339,368 @@ tail.
 **Sections nest.** `SectionChunk.level` is the engine's font-statistics
 heading level — the same value the renderers use for `#`/`##`/`###`
 depth — so big headings contain small ones: a level-4 section's `path`
-carries all its ancestors (`["Paper Title", "…", "AUTHOR INFORMATION",
-"Corresponding Author"]`), and `cd.hierarchy` exposes the same nesting
+carries all its ancestors, and `cd.hierarchy` exposes the same nesting
 as a `SectionNode` tree (root level 0). The section tree therefore
 always matches the heading depth visible in the rendered markdown.
 
-A real document makes the ownership rules concrete (a 21-page slice of
-the ISO 32000-2 specification, abridged; `own` = chunks whose
-`section_id` is this section, `subtree` = the rollup):
+A real document makes the ownership rules concrete. `tests/test_370.pdf`
+is a five-page paper with nested headings; `own` = chunks whose
+`section_id` is this section, `subtree` = the rollup over the section and
+everything nested under it:
 
+```python
+cd_p = pymupdf4llm.to_chunks("tests/test_370.pdf")
+own = {}
+for c in cd_p:
+    own.setdefault(c.metadata.section_id, []).append(c.id)
+for s in cd_p.sections:
+    print("   " * (s.level - 1) + f"{s.id} L{s.level} {s.title[:22]!r}",
+          f"own={own.get(s.id, [])}",
+          f"subtree={len(s.child_chunk_ids)}ch/{s.token_count}tok")
 ```
-s0 L1 'International Standard ISO 32000-2'  own=[c1]      subtree=36ch/12,953tok
-└─ s1 L2 'ISO 32000-2'                      own=[c2]      subtree=35ch/12,813tok
-   ├─ s2 L6 'COPYRIGHT PROTECTED DOCUMENT'  own=[c3]      (heading-only)
-   ├─ s4 L4 'Foreword'                      own=[c9,c10]
-   ├─ s5 L4 'Introduction'                  own=[c11]     subtree=13ch/3,454tok
-   │  ├─ s6 L5 '0.1 PDF'                    own=[c12–c14]
-   │  └─ s9 L5 '0.4 Changes introduced …'   own=[c21–c23]
-   └─ s10 L3 'Document management — …'      own=[c24]     (L5 → L3: stack pops back)
-      └─ s11 L4 '1 Scope'                   own=[c25]
+
+```text
+s0 L1 'Synthesis of Silyl Die' own=['c0'] subtree=21ch/4711tok
+   s1 L2 'Masahiro Sai' own=['c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8', 'c9', 'c10'] subtree=20ch/4688tok
+      s2 L3 'AUTHOR INFORMATION' own=['c11'] subtree=3ch/43tok
+         s3 L4 'Corresponding Author' own=['c12'] subtree=1ch/21tok
+         s4 L4 'Notes' own=['c13'] subtree=1ch/16tok
+      s5 L3 'ACKNOWLEDGMENT' own=['c14'] subtree=1ch/24tok
+      s6 L3 'REFERENCES' own=['c15', 'c16', 'c17', 'c18', 'c19', 'c20'] subtree=6ch/1637tok
 ```
+
+`s5` shows the stack popping back: after the level-4 `Notes`, a level-3
+heading closes both `s4` and `s2` and becomes a sibling of `s2`.
 
 - **Ownership is innermost.** Content attaches at whatever depth it
-  appears (chunks above sit at L3, L4, L5, and L6): a paragraph after
-  `0.1 PDF` gets `section_id="s6"` and
-  `section_path=[…, "Introduction", "0.1 PDF"]` — one unambiguous
-  address per chunk.
+  appears: the `Corresponding Author` heading and the e-mail line under
+  it form chunk `c12` with `section_id="s3"` and
+  `section_path=[..., "AUTHOR INFORMATION", "Corresponding Author"]`,
+  one unambiguous address per chunk.
 - **Heading-only sections** still exist in the tree, owning just their
-  own heading chunk (s2) until a same-or-shallower heading closes them.
-  A parent like s5 "Introduction" similarly owns only its heading chunk
-  while the content lives in its child sections.
-- **Ancestors aggregate.** `child_chunk_ids` and `token_count` cover
-  the whole subtree (s5 rolls up 13 chunks / 3,454 tokens), and
-  `element_span`s nest: s5 `(58, 219)` contains s6 `(59, 88)` — feed a
-  whole branch to an LLM via `SectionChunk.text`.
+  own heading chunk (`s2` owns `c11`, the 6-token `### **AUTHOR
+  INFORMATION**` line) until a same-or-shallower heading closes them;
+  the content lives in the child sections `s3` and `s4`.
+- **Ancestors aggregate.** `child_chunk_ids` and `token_count` cover the
+  whole subtree (`s2` rolls up `["c11", "c12", "c13"]`, 43 tokens), and
+  `element_span`s nest: `s2` `(34, 39)` contains `s3` `(35, 37)`. Feed a
+  whole branch to an LLM via `SectionChunk.text` (recipe 6).
 - **Before the first heading**, chunks stay unowned: `section_id=None`,
-  `section_path=[]` (a cover-page figure, for instance).
+  `section_path=[]` (a cover-page figure, for instance; a document with
+  no headings at all, such as `tests/test_sce_150_1.pdf`, has
+  `cd.sections == []` and every chunk unowned).
 
 ## Cookbook
 
-Every snippet below runs as-is against the repo's example document —
-six pages of capital-city tables. Output lines (`# ->`) are real,
-captured on pymupdf 1.28.2:
+The recipes below are for people building a retrieval pipeline on top of
+`to_chunks()`. Each one runs as-is from the repository root against a PDF
+shipped with the repository, and every `# ->` line is real output
+captured on pymupdf 1.28.2.
+
+**Reader-side placeholders.** The recipes need things pymupdf4llm does
+not provide: an embedding model, a vector store, a keyword index, a
+retriever, an LLM. Each recipe defines the ones it needs as tiny stand-in
+stubs between a `# --- your code: ... ---` and a `# --- end of your code ---`
+comment; replace those with your own implementations. Everything outside
+those markers is pymupdf4llm API: every attribute or method called on
+`cd`, on a chunk, or on a table/figure/section view is documented in the
+sections above.
+
+`cd` in the recipes is the example document, six pages of capital-city
+tables; recipes that use another PDF parse it themselves:
 
 ```python
+import pymupdf4llm
+
 cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf")
-# -> len(cd) == 6
-# c0: type='table' tokens=351 elements=['p1.b0', 'p1.b1', 'p1.b2']
-# c1: type='table' tokens=377 elements=['p2.b0']
-# ...
+for c in cd:
+    print(c.id, c.metadata.types, c.metadata.token_count, c.metadata.element_ids)
+# -> c0 ['heading', 'paragraph', 'table'] 351 ['p1.b0', 'p1.b1', 'p1.b2']
+#    c1 ['table'] 377 ['p2.b0']
+#    c2 ['table'] 365 ['p3.b0']
+#    c3 ['table'] 373 ['p4.b0']
+#    c4 ['table'] 399 ['p5.b0']
+#    c5 ['table'] 369 ['p6.b0']
 ```
 
-### 1. Embed with context
+### 1. Embed with context and upsert with stable ids
+
+Embed `contextual_text`, not `text`: it prefixes the section path, page
+and element types, so the vector carries where the chunk sits in the
+document. `[Section]` comes from the layout-detected heading structure;
+this document has no PDF bookmarks, and none are needed.
 
 ```python
-for c in cd:
-    embed(c.contextual_text)   # includes section path + page + type tags
-
-# c0.contextual_text ->
-# [Section] World Capital Cities
-# [Page] 1
-# [Type] heading, table
-# [Content]
-# # **World Capital Cities**
-# _Percent "%" is city population as a percentage of the country, ..._
+print(cd[0].contextual_text[:130])
+# -> [Section] World Capital Cities
+#    [Page] 1
+#    [Type] heading, table
+#    [Content]
+#    # **World Capital Cities**
+#    _Percent "%" is city population
 ```
 
-(`[Section]` comes from the layout-detected heading structure — this
-document has no PDF bookmarks, and none are needed.)
+Assemble the vector-store point id from stable scopes; re-ingesting the
+same document version then *updates* instead of duplicating. Keep ids for
+machines and citations (`section_path`, pages) for humans: never show a
+point id to a user, never parse a citation back into an id. Treat the id
+assembly rule as immutable code, since changing it re-keys the whole
+collection.
+
+```python
+# --- your code: replace with your embedding model and vector store ---
+def embed(text):
+    return [0.0] * 8                 # stand-in for an embedding vector
+
+class VectorStore:
+    def __init__(self):
+        self.points = {}
+
+    def upsert(self, id, vector, payload):
+        self.points[id] = (vector, payload)
+
+store = VectorStore()
+doc_id = "9f2d"                      # your document identity, e.g. sha256 of the file bytes
+# --- end of your code ---
+
+def point_id(c, *, tenant, kb, doc_id, emb_ver):
+    return f"{tenant}:{kb}:{doc_id}:{c.metadata.page_start}:{c.id}:{emb_ver}"
+
+for c, payload in zip(cd, cd.to_dicts()):
+    store.upsert(
+        id=point_id(c, tenant="acme", kb="manuals", doc_id=doc_id, emb_ver="e5-large-v2"),
+        vector=embed(c.contextual_text),
+        payload={**payload, "citation": {
+            "section": " > ".join(c.metadata.section_path),
+            "pages": [c.metadata.page_start, c.metadata.page_end]}},
+    )
+
+pid = point_id(cd[0], tenant="acme", kb="manuals", doc_id=doc_id, emb_ver="e5-large-v2")
+print(pid)
+# -> acme:manuals:9f2d:1:c0:e5-large-v2
+print(store.points[pid][1]["citation"])
+# -> {'section': 'World Capital Cities', 'pages': [1, 1]}
+```
+
+On re-ingest, `content_hash` (sha256 of whitespace-normalized chunk text)
+tells you which chunks actually changed, so only those are re-embedded:
+
+```python
+# --- your code: content hashes stored by the previous ingest, keyed by chunk id ---
+previous = {c.id: c.content_hash for c in cd}      # here: the same document, unchanged
+# --- end of your code ---
+
+changed = [c for c in cd if previous.get(c.id) != c.content_hash]
+print(len(changed), cd[0].content_hash[:16])
+# -> 0 6adc89bfaeef7db4
+```
 
 ### 2. Ingestion gate wiring
 
 `cd.diagnostics` is the machine-readable input for a PROCEED/HOLD/REJECT
-decision — it reports facts; your pipeline owns the thresholds. This is
+decision. It reports facts; your pipeline owns the thresholds. This is
 how you catch "a perfectly fine document quietly produced 0 chunks"
 before it poisons an index:
 
 ```python
-d = cd.diagnostics
-# -> {"chunk_count": 6, "element_count": 14, "table_count": 6,
-#     "figure_count": 0, "section_count": 1, "page_count": 6,
-#     "pages_without_chunks": [], "zero_chunk_causes": [],
-#     "figures_without_text": [], "degenerate_tables": [],
-#     "header_footer_excluded": 6}
+def gate(d):
+    """Verdict from cd.diagnostics; the rules are yours to tune."""
+    if d["chunk_count"] == 0:
+        return "REJECT", d["zero_chunk_causes"]                 # nothing usable
+    if d["pages_without_chunks"] or d["degenerate_tables"]:
+        return "HOLD", {"pages": d["pages_without_chunks"],
+                        "tables": d["degenerate_tables"]}      # human review
+    if d["figures_without_text"]:
+        return "PROCEED_WITH_OCR_QUEUE", d["figures_without_text"]
+    return "PROCEED", None
 
-if d["chunk_count"] == 0:
-    verdict = ("REJECT", d["zero_chunk_causes"])          # nothing usable
-elif d["pages_without_chunks"] or d["degenerate_tables"]:
-    verdict = ("HOLD", {"pages": d["pages_without_chunks"],
-                        "tables": d["degenerate_tables"]})  # human review
-elif d["figures_without_text"]:
-    verdict = ("PROCEED_WITH_OCR_QUEUE", d["figures_without_text"])
-else:
-    verdict = ("PROCEED", None)
-# -> ("PROCEED", None)
+print(cd.diagnostics)
+# -> {'chunk_count': 6, 'element_count': 14, 'table_count': 6, 'figure_count': 0,
+#     'section_count': 1, 'page_count': 6, 'pages_without_chunks': [],
+#     'zero_chunk_causes': [], 'figures_without_text': [], 'degenerate_tables': [],
+#     'header_footer_excluded': 6}
+print(gate(cd.diagnostics))
+# -> ('PROCEED', None)
 ```
 
-### 3. Idempotent vector-store upserts
+### 3. Tables and figures as first-class citations
 
-Assemble the point id from stable scopes; re-ingesting the same document
-version then *updates* instead of duplicating. Keep ids for machines and
-citations (`section_path`, pages) for humans — never show a point id to a
-user, never parse a citation back into an id:
+`cd.tables` and `cd.figures` give every table and figure its own id, page
+and bbox, plus the chunk that holds it, so they can be indexed and cited
+on their own. `tests/test_tablulate_bug.pdf` is a one-page document with
+two tables and two figures:
 
 ```python
-def point_id(c, *, tenant, kb, doc_id, emb_ver):
-    return f"{tenant}:{kb}:{doc_id}:{c.metadata.page_start}:{c.id}:{emb_ver}"
-# point_id(cd[0], tenant="acme", kb="manuals", doc_id="9f2d...",
-#          emb_ver="e5-large-v2")
-# -> "acme:manuals:9f2d...:1:c0:e5-large-v2"
-# citation -> {"section": "World Capital Cities", "pages": [1, 1]}
+cd_t = pymupdf4llm.to_chunks("tests/test_tablulate_bug.pdf")
+print(cd_t)
+# -> ChunkedDocument(chunks=4, tables=2, figures=2, sections=4)
 
-for c, payload in zip(cd, cd.to_dicts()):
-    store.upsert(id=point_id(c, tenant="acme", kb="manuals",
-                             doc_id=sha, emb_ver="e5-large-v2"),
-                 vector=embed(c.contextual_text),
-                 payload=payload | {"citation": {
-                     "section": " > ".join(c.metadata.section_path),
-                     "pages": [c.metadata.page_start, c.metadata.page_end]}})
+# --- your code: replace with your table index and OCR queue ---
+table_index = {}
+ocr_queue = []
+# --- end of your code ---
+
+for t in cd_t.tables:
+    table_index[t.id] = {"text": t.text, "headers": t.headers,
+                         "cite": (t.page, t.bbox),
+                         "context": cd_t.get(t.chunk_id).text}   # the whole owning chunk
+    print(t.id, t.chunk_id, t.page, t.headers, t.text[:27])
+# -> t0 c1 1 [] |**Targets**|**Weighting**|
+#    t1 c3 1 [] ||||||||**Total value of**|
+
+for f in cd_t.figures:
+    if not f.has_text:                                        # no extractable text
+        ocr_queue.append((f.id, f.page, f.bbox))
+print(ocr_queue)
+# -> [('f1', 1, (758.0, 152.0, 1021.0, 265.0)), ('f2', 1, (758.0, 336.0, 1021.0, 372.0))]
+print(cd_t.diagnostics["figures_without_text"])
+# -> ['f1', 'f2']      (the same ids, if you prefer to read them from diagnostics)
 ```
 
-Treat the assembly rule as immutable code: changing it re-keys the whole
-collection.
-
-### 4. Change detection / dedup with content_hash
+For header-aware table retrieval, parse with `table_output="html"`:
+`t.text` becomes the engine's HTML (colspan/rowspan preserved) and
+`t.headers` carries the `<th>` cell texts, but only when the engine's
+header detection fires; otherwise `headers` stays `[]`, exactly as on
+markdown parses:
 
 ```python
-prev = {r["id"]: r["content_hash"] for r in previous_ingest}
-changed = [c for c in cd if prev.get(c.id) != c.content_hash]
-re_embed(changed)              # first stage of multi-stage dedup
-
-# cd[0].content_hash -> "6adc89bfaeef7db4..." (sha256, whitespace-normalized)
-# unchanged document -> changed == []
+cd_h = pymupdf4llm.to_chunks("tests/test_sce_150_1.pdf", table_output="html")
+t1 = cd_h.get("t1")
+print(t1.markdown, "<th" in t1.html, t1.headers)
+# -> None True ['Alternate Calculation with Reinsurance', '', '', '']
 ```
 
-### 5. Tables and figures as first-class citations
+### 4. Context window around a hit
+
+A `ChunkedDocument` is a list in reading order, so the chunks around a
+search hit are just a slice around its position. Nothing is stored per
+chunk for this; `c{n}` is the position, and `cd.index()` gives it for a
+chunk object.
 
 ```python
-for t in cd.tables:
-    index_table(t.id, t.text, headers=t.headers,
-                cite=(t.page, t.bbox), context_chunk=cd.get(t.chunk_id).text)
-# t0: chunk=c0 page=1 text starts
-#     "|**Country**|**Capital**|**Population**|**%**|**Year**|"
+hit = cd.get("c3")                    # the chunk id your search returned
+i = cd.index(hit)                     # 3
+window = cd[max(0, i - 2): i + 3]     # two before, the hit, two after
+print([c.id for c in window])
+# -> ['c1', 'c2', 'c3', 'c4', 'c5']
 
-for f in cd.figures:
-    if not f.has_text:
-        ocr_queue.append((f.id, f.page, f.bbox))   # from diagnostics too
+edge = cd[max(0, 0 - 2): 0 + 3]       # a hit on c0: the slice simply clamps
+print([c.id for c in edge])
+# -> ['c0', 'c1', 'c2']
 ```
 
-For header-aware table retrieval, parse with
-`to_chunks("doc.pdf", table_output="html")`: `t.text` becomes the engine's
-HTML (colspan/rowspan preserved) and `t.headers` carries the `<th>` cell
-texts — but only when the engine's header detection fires; otherwise
-`headers` stays `[]`, exactly as on markdown parses. Captured from the
-repo's `tests/test_sce_150_1.pdf`:
+### 5. Budget tuning and small-to-big retrieval
 
-```python
-cd = pymupdf4llm.to_chunks("tests/test_sce_150_1.pdf", table_output="html")
-# t1: markdown=None, "<th" in t1.html,
-#     headers=['Alternate Calculation with Reinsurance', '', '', '']
-```
-
-### 6. Retrieval-time context expansion
-
-Chunks are ordered; position replaces stored neighbor links:
-
-```python
-hit = cd.get("c1")
-i = int(hit.id[1:])
-window = cd[max(0, i - 2): i + 3]
-# -> [c0, c1, c2, c3]  (clamped at document edges)
-```
-
-### 7. Budget tuning without re-parsing
-
-Different budgets serve different consumers — the default 400 targets
+Different budgets serve different consumers: the default 400 targets
 embedding-model inputs; 800–1200 suits rerankers and long-context
-synthesis; ~2000 suits section-first keyword retrieval (recipe 9). One
+synthesis; ~2000 suits section-first keyword retrieval (recipe 6).
+`reassemble_chunks()` re-runs assembly from the retained units, so one
 parse serves them all:
 
 ```python
-cd = pymupdf4llm.to_chunks("big.pdf")          # parse once
 for budget in (200, 400, 800):
-    evaluate(cd.reassemble_chunks(max_tokens=budget))    # milliseconds each
-# on the 6-page example: 200 -> 7 chunks, 400 -> 6, 800 -> 3, ~1 ms each
+    print(budget, len(cd.reassemble_chunks(max_tokens=budget)))
+# -> 200 7
+#    400 6
+#    800 3        (about a millisecond each; no re-parse)
 ```
 
 Measured on a 1,003-page reference PDF (pymupdf 1.28.2): parse ~36 min
-once, then `reassemble_chunks()` 0.7–1.2 s per budget — three orders of magnitude
-cheaper than re-parsing per configuration.
+once, then `reassemble_chunks()` 0.7–1.2 s per budget — three orders of
+magnitude cheaper than re-parsing per configuration.
 
-### 8. Small-to-big retrieval
-
-Search precisely over small chunks, feed the LLM the surrounding big
-chunk. Both granularities come from the same parse and share element
-addresses, so the mapping is a set intersection — no extra bookkeeping:
+Small-to-big retrieval is the same idea at query time: search precisely
+over small chunks, feed the LLM the surrounding big chunk. Both
+granularities come from the same parse and share element addresses, so
+the mapping is a set intersection, no extra bookkeeping:
 
 ```python
-cd = pymupdf4llm.to_chunks("doc.pdf")          # small: 400 tok, indexed
-big = cd.reassemble_chunks(max_tokens=1200)              # big: LLM context
+big = cd.reassemble_chunks(max_tokens=1200)     # 2 chunks: c0 pages 1-3, c1 pages 4-6
 
-hit = search(query)                            # returns a small chunk id
-small = cd.get(hit)
+# --- your code: replace with your retriever and LLM ---
+def search(query):
+    return "c1"                       # a small-chunk id from your index
+
+def llm(query, context):
+    return f"answer grounded in {len(context)} characters"
+# --- end of your code ---
+
+query = "What is the capital of Belgium?"
+small = cd.get(search(query))                   # from cd, the 400-token index
 context = next(b for b in big
-               if set(small.metadata.element_ids)
-                  & set(b.metadata.element_ids))
+               if set(small.metadata.element_ids) & set(b.metadata.element_ids))
 answer = llm(query, context.text)
-# on the example: hit c1 (377 tok) -> big c0 (1,093 tok, pages 1-3)
+print(small.id, small.metadata.token_count, "->", context.id,
+      context.metadata.token_count, context.metadata.page_start, context.metadata.page_end)
+# -> c1 377 -> c0 1093 1 3
 ```
 
-### 9. Section-first chunking for keyword / non-embedding retrieval
+### 6. Section-first chunking for keyword search and browsing
 
-BM25-style and navigational retrieval usually wants section-shaped
-units around ~2000 tokens rather than embedding-sized ones. Large
-budgets keep section purity because a section-opening chunk never
-budget-merges backward (`respect_section_starts=True`, the default):
+Keyword search without embeddings, and browsing a document by section,
+usually want section-shaped units around ~2000 tokens rather than
+embedding-sized ones. Large budgets keep section purity because a
+section-opening chunk never budget-merges backward
+(`respect_section_starts=True`, the default). `tests/test_370.pdf` is a
+five-page paper with 7 sections:
 
 ```python
-cd = pymupdf4llm.to_chunks("paper.pdf")
-big = cd.reassemble_chunks(max_tokens=2000)
+cd_p = pymupdf4llm.to_chunks("tests/test_370.pdf")
+big = cd_p.reassemble_chunks(max_tokens=2000)
 by_section = {}
 for c in big:
-    by_section.setdefault(c.metadata.section_id, []).append(c)
-# tests/test_370.pdf (7 sections) -> 8 chunks, each inside one section:
-#   s0: [c0]  s1: [c1, c2]  s2: [c3]  s3: [c4] ...
-# with respect_section_starts=False -> 3 chunks, sections glued together
+    by_section.setdefault(c.metadata.section_id, []).append(c.id)
+print(len(big), by_section)
+# -> 8 {'s0': ['c0'], 's1': ['c1', 'c2'], 's2': ['c3'], 's3': ['c4'],
+#       's4': ['c5'], 's5': ['c6'], 's6': ['c7']}
+#    every chunk sits inside exactly one section
+
+glued = cd_p.reassemble_chunks(max_tokens=2000, respect_section_starts=False)
+print(len(glued), [c.metadata.section_id for c in glued])
+# -> 3 ['s1', 's1', 's6']      sections packed together
 ```
 
-Index each entry under `" > ".join(chunk.metadata.section_path)` for
-navigable, citable results.
+Index each entry under `" > ".join(chunk.metadata.section_path)` so a hit
+can be shown and navigated by section.
 
 The sections view itself is often the better keyword-search unit. A
-chunk hit can be a heading-only chunk (a subheading followed directly
-by its own subheading carries no body text), but a section is never
-under-evidenced: `SectionChunk.text` lazily assembles the section's
-whole subtree — its heading plus every child section's content — and
-`token_count` is the subtree rollup, so oversized branches are easy to
-filter before indexing:
+chunk hit can be a heading-only chunk (a heading followed directly by a
+subheading carries no body text), but a section is never under-evidenced:
+`SectionChunk.text` assembles the section's whole subtree, its heading
+plus every child section's content, and `token_count` is the subtree
+rollup, so oversized branches are easy to filter before indexing:
 
 ```python
-for s in cd.sections:
-    if s.token_count <= 4000:            # whole subtree fits the budget
-        keyword_index(s.id, s.text, path=" > ".join(s.path))
+# --- your code: replace with your keyword index ---
+keyword_index = {}
+# --- end of your code ---
 
-# or expand a chunk hit to its owning section at query time:
-hit = cd.get("c11")                      # '#### **Introduction**', 5 tok
-evidence = cd.get(hit.metadata.section_id).text
-# ISO 32000-2 slice -> the 'Introduction' section text: its heading plus
-# all of 0.1-0.4, 3,454 tokens - sufficient grounds instead of one line
+for s in cd_p.sections:
+    if s.token_count <= 4000:              # whole subtree fits the budget
+        keyword_index[s.id] = {"text": s.text, "path": " > ".join(s.path)}
+print(sorted(keyword_index))
+# -> ['s2', 's3', 's4', 's5', 's6']      (s0 and s1 span the whole paper: 4711 / 4688 tokens)
+
+# Or expand a chunk hit to its owning section at query time:
+hit = cd_p.get("c11")
+print(repr(hit.text), hit.metadata.token_count, hit.metadata.section_id)
+# -> '### **AUTHOR INFORMATION**' 6 s2           (a heading-only chunk)
+section = cd_p.get(hit.metadata.section_id)
+print(section.token_count, section.child_chunk_ids, section.text[:87])
+# -> 43 ['c11', 'c12', 'c13'] ### **AUTHOR INFORMATION**
+#
+#    #### **Corresponding Author**
+#
+#    *saimasa@mat.shimane-u.ac.jp
 ```
 
-### 10. Framework export
+### 7. Framework export
 
 ```python
 docs = cd.to_langchain_documents()   # needs langchain-core
 nodes = cd.to_llama_nodes()          # needs llama-index-core
 # -> 6 Documents / 6 TextNodes; docs[0].page_content == cd[0].text,
-#    metadata keys: bboxes, chunk_type, chunk_types, element_ids, ...
+#    metadata: the ChunkMetadata fields (page_start, page_end, bboxes, types, ...)
 ```
 
 ## contextual_text Format
@@ -502,13 +708,14 @@ nodes = cd.to_llama_nodes()          # needs llama-index-core
 ```
 [Section] Chapter 1 > Section 1.2
 [Page] 5
-[Type] table
+[Type] heading, table
 [Content]
 {chunk.text}
 ```
 
 - `[Section]` appears only when `section_path` is non-empty.
-- `[Type]` appears only when the type is not `"paragraph"`.
+- `[Type]` lists `metadata.types` without `"paragraph"`; the line is
+  omitted when `"paragraph"` is the only type.
 
 ## Token counting
 

--- a/CHUNKING.md
+++ b/CHUNKING.md
@@ -122,9 +122,9 @@ rejects them — re-parse via `to_chunks()` to change them.
 | `tokenizer` | `None` | tiktoken encoding name (unknown names raise `ValueError`), a `callable(text) -> int`, or `None` (character estimate) |
 | `weights` | `None` | Boundary-score weight overrides |
 
-Whether `contextual_text` is included in exports is decided at export
+Whether `tagged_content` is included in exports is decided at export
 time: `ChunkedDocument.to_dicts()` / `.to_json()` take a keyword-only
-`include_contextual` (default `True`).
+`include_tagged` (default `True`).
 
 ### Choosing a budget
 
@@ -195,7 +195,7 @@ cd.get("nope", default=None)   # KeyError without default=
 # Exports (JSON-safe; content_hash included)
 cd.to_dicts()                  # list[dict], schema below
 cd.to_json(indent=2)           # json.dumps(cd.to_dicts()); extra kwargs go to json.dumps
-cd.to_dicts(include_contextual=False)   # drop contextual_text from the payload
+cd.to_dicts(include_tagged=False)   # drop tagged_content from the payload
 # Framework exports need optional dependencies (recipe 7):
 #   cd.to_langchain_documents()   -> list[langchain_core.documents.Document]
 #   cd.to_llama_nodes()           -> list[llama_index.core.schema.TextNode]
@@ -204,7 +204,6 @@ cd.to_dicts(include_contextual=False)   # drop contextual_text from the payload
 cd.reassemble_chunks(max_tokens=200)   # new ChunkedDocument from retained units, no re-parse
 cd.diagnostics                 # dict for an ingestion gate (keys below)
 cd.params                      # read-only mapping of the parameters cd was built with
-cd.contextualize(cd[0])        # == cd[0].contextual_text
 ```
 
 `reassemble_chunks()` accepts assembly-tier parameters only (`max_tokens`,
@@ -220,7 +219,7 @@ cd.contextualize(cd[0])        # == cd[0].contextual_text
 Chunk:
     id: str                    # "c0", "c1", ... (position in this ChunkedDocument)
     text: str                  # markdown, identical to to_markdown's rendering
-    contextual_text: str       # text with [Section], [Page], [Type] tags (format below)
+    tagged_content: str       # text with [Section], [Page], [Type] tags (format below)
     content_hash: str          # lazy sha256 of whitespace-normalized text
     metadata: ChunkMetadata
 ```
@@ -253,7 +252,7 @@ One dict per chunk; `metadata` carries every `ChunkMetadata` field as-is:
     "id": "c0",
     "text": "...",
     "content_hash": "6adc89bf...",
-    "contextual_text": "...",          # omitted with include_contextual=False
+    "tagged_content": "...",          # omitted with include_tagged=False
     "metadata": {
         "page_start": 1, "page_end": 1, "bboxes": [...],
         "types": ["heading", "paragraph", "table"],
@@ -425,17 +424,17 @@ for c in cd:
 
 ### 1. Embed with context and upsert with stable ids
 
-Embed `contextual_text`, not `text`: it prefixes the section path, page
+Embed `tagged_content`, not `text`: it prefixes the section path, page
 and element types, so the vector carries where the chunk sits in the
 document. `[Section]` comes from the layout-detected heading structure;
 this document has no PDF bookmarks, and none are needed.
 
 ```python
-print(cd[0].contextual_text[:130])
+print(cd[0].tagged_content[:130])
 # -> [Section] World Capital Cities
 #    [Page] 1
 #    [Type] heading, table
-#    [Content]
+#    [Markdown]
 #    # **World Capital Cities**
 #    _Percent "%" is city population
 ```
@@ -469,7 +468,7 @@ def point_id(c, *, tenant, kb, doc_id, emb_ver):
 for c, payload in zip(cd, cd.to_dicts()):
     store.upsert(
         id=point_id(c, tenant="acme", kb="manuals", doc_id=doc_id, emb_ver="e5-large-v2"),
-        vector=embed(c.contextual_text),
+        vector=embed(c.tagged_content),
         payload={**payload, "citation": {
             "section": " > ".join(c.metadata.section_path),
             "pages": [c.metadata.page_start, c.metadata.page_end]}},
@@ -703,13 +702,13 @@ nodes = cd.to_llama_nodes()          # needs llama-index-core
 #    metadata: the ChunkMetadata fields (page_start, page_end, bboxes, types, ...)
 ```
 
-## contextual_text Format
+## tagged_content Format
 
 ```
 [Section] Chapter 1 > Section 1.2
 [Page] 5
 [Type] heading, table
-[Content]
+[Markdown]
 {chunk.text}
 ```
 

--- a/CHUNKING.md
+++ b/CHUNKING.md
@@ -1,0 +1,523 @@
+# Layout-Aware Chunking API
+
+`pymupdf4llm.to_chunks()` splits a PDF into retrieval-friendly chunks using
+PDF-native layout signals (box boundaries, font changes, vertical gaps, page
+breaks) and returns a `ChunkedDocument` — a sequence of chunks plus the
+document's structure: an element registry, table/figure/section views, a
+section hierarchy, and ingestion diagnostics.
+
+Chunk text is the **same markdown** `to_markdown()` emits for the same
+boxes (rendered through the same renderers), so chunks never carry glued
+words the renderer would have spaced correctly — a direct hit on
+sparse/BM25 recall: a term glued to its neighbor is a term your keyword
+index cannot match.
+
+## Quick Start
+
+```python
+import pymupdf4llm
+
+cd = pymupdf4llm.to_chunks("input.pdf")
+
+for c in cd:
+    print(c.id, c.metadata.chunk_type, c.text[:80])
+```
+
+## Two Ways to Call
+
+```python
+# 1. One-step: file path or pymupdf.Document
+cd = pymupdf4llm.to_chunks("input.pdf", max_tokens=400)
+
+# 2. Two-step: parse first, then chunk
+from pymupdf4llm.helpers.document_layout import parse_document
+
+doc = parse_document("input.pdf")
+cd = doc.to_chunks(max_tokens=400)
+```
+
+The one-step form accepts both parse and chunk parameters; they are split
+internally by the `parse_document` signature. Unknown chunking parameters
+raise `TypeError`. (`to_chunk()` still works but emits a
+`DeprecationWarning`.)
+
+## At a Glance
+
+One slow layout extraction feeds one reusable substrate; everything
+downstream — assembly, views, exports, re-chunking — is cheap:
+
+```mermaid
+flowchart LR
+    pdf["PDF"] -->|"parse parameters<br/>slow · runs once"| parse["parse_document()<br/>layout extraction"]
+    parse --> sub["substrate<br/>element registry + units"]
+    sub -->|"chunk parameters<br/>fast"| asm["assembly"]
+    asm --> cd["ChunkedDocument"]
+    cd --> chunks["chunks<br/>text == to_markdown"]
+    cd --> views["tables · figures · sections<br/>hierarchy · diagnostics"]
+    cd --> out["to_dicts() / to_json()<br/>→ vector DB / RAG"]
+    cd -.->|"reassemble_chunks() — milliseconds,<br/>no re-parse"| asm
+```
+
+The two parameter tiers below map onto the two arrows: parse parameters
+change the substrate (re-parse required), chunk parameters only change
+assembly (`reassemble_chunks()` is enough).
+
+## Parameters
+
+### Parse Parameters
+
+Passed to `parse_document()` internally.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `pages` | `None` | Pages to process (`None`=all, or list of 0-based page numbers) |
+| `dpi` / `image_dpi` | `150` | Image extraction DPI |
+| `ocr_dpi` | `150` | OCR DPI |
+| `use_ocr` | (select) | OCR mode |
+| `force_ocr` | `False` | Force OCR on all pages |
+| `ocr_language` | `"eng"` | OCR language |
+| `table_output` | `"markdown"` | `"html"` opts into the engine HTML table model (like `to_markdown`); needs a PyMuPDF with the layout-union table model, degrades to markdown tables with a warning otherwise. Changes `TableChunk` content per D15 (see Views) and re-splits boxes (see IDs) |
+| `edge_threshold` | `None` | Layout GNN edge-probability cut for box grouping (engine default 0.55; lower merges more, higher fragments more) |
+| `show_progress` | `False` | Show progress bar |
+
+`table_output` and `edge_threshold` are substrate options: `reassemble_chunks()`
+rejects them — re-parse via `to_chunks()` to change them.
+
+### Chunk Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `max_tokens` | `400` | Maximum tokens per chunk. The default targets embedding-model inputs; larger budgets (800–2000) suit long-context synthesis, rerankers, and section-first keyword retrieval — see recipes 7–9 |
+| `min_tokens` | `120` | Minimum tokens (merge threshold) |
+| `breakpoint_threshold` | `0.5` | Boundary score threshold for splitting |
+| `merge_small_chunks` | `True` | Merge undersized chunks with neighbors |
+| `table_mode` | `"preserve"` | `"preserve"`: table = one chunk; `"isolate"`: tables never budget-merge |
+| `respect_section_starts` | `True` | Never budget-merge a section-opening chunk into the previous section's tail — chunk boundaries respect detected headings. Set `False` for pure token packing |
+| `header_footer_mode` | `"exclude"` | `"exclude"` / `"auto"` (repeat detection) / `"include"` |
+| `sentence_splitter` | `"default"` | `"default"` (English) or `"multilingual"` (CJK support) |
+| `tokenizer` | `None` | tiktoken encoding name (unknown names raise `ValueError`), a `callable(text) -> int`, or `None` (character estimate) |
+| `weights` | `None` | Boundary-score weight overrides |
+
+`to_chunks()` no longer takes `output_format` or `include_contextual_text`;
+`ChunkedDocument.to_dicts()` / `.to_json()` take a keyword-only
+`include_contextual` (default `True`) instead.
+
+### Choosing a budget
+
+The 400-token default sits in the evidence-supported band for
+general-purpose retrieval: chunking ablations find ~200 tokens best for
+precision-oriented fact QA and 512–1024 for synthesis/analytical tasks,
+with both extremes losing (Chroma, *Evaluating Chunking Strategies*;
+NVIDIA, *Finding the Best Chunking Strategy*, 2025). Long-context
+embedding models did not move this — their windows go to context
+conditioning (late chunking, contextualized chunk embeddings), not to
+bigger retrieval units. Layout-aware boundaries matter more than the
+exact number (structure-based splitting beats size tuning in 2025–26
+studies), and on layout-rich documents only ~10–40% of chunks hit the
+budget cap at all — the rest end at headings, tables, and boxes. When a
+different consumer needs a different size, `reassemble_chunks()` is the intended
+answer (recipes 7–9), not a changed default.
+
+## IDs Are a Contract
+
+Every id format is stable across versions:
+
+| Kind | Format | Example |
+|---|---|---|
+| chunk | `c{n}` | `c12` |
+| table | `t{n}` | `t0` |
+| figure | `f{n}` | `f3` (same `n` as `[Figure f3: WxH]` placeholders) |
+| section | `s{n}` | `s2` |
+| element | `p{page}.b{box}` | `p5.b7` (1-based page, 0-based box) |
+
+**Scope**: element ids are stable for the same *(document bytes, package
+version, parse options)*. Parse modes that re-split boxes (e.g. HTML
+table rendering) change box indices — never cache ids across parse-option
+changes.
+
+`cd.get(id)` resolves any of these; raises `KeyError` for an unknown id
+unless you pass `default=`.
+
+## ChunkedDocument
+
+```python
+cd = pymupdf4llm.to_chunks("input.pdf")
+
+len(cd), cd[0], cd[2:5]        # Sequence[Chunk]
+cd.chunks                      # chunks as a tuple (== tuple(cd))
+cd.text                        # lazy full text (chunks joined)
+cd.elements                    # every layout box, header/footer included
+cd.tables, cd.figures, cd.sections   # views, linked to chunks both ways
+cd.hierarchy                   # sections as a SectionNode tree (root level 0)
+cd.diagnostics                 # ingestion-gate input (see recipe 2)
+cd.to_dicts(), cd.to_json()    # JSON-safe, content_hash included; include_contextual=True by default
+cd.contextualize(cd[0])        # == cd[0].contextual_text
+cd.reassemble_chunks(max_tokens=200)     # cheap re-assembly from retained units
+cd.params                      # read-only mapping of the params used to build cd
+```
+
+`reassemble_chunks()` accepts assembly-tier parameters only (`max_tokens`,
+`min_tokens`, `breakpoint_threshold`, `table_mode`, `merge_small_chunks`,
+`respect_section_starts`). Substrate parameters (`sentence_splitter`,
+`header_footer_mode`, `tokenizer`, `weights`) and parse options raise
+`ValueError` — call `to_chunks()` on a new parse instead.
+
+### Chunk
+
+```python
+Chunk:
+    id: str                    # "c0", "c1", ... (chunk_id is a read-only alias)
+    text: str                  # markdown, identical to to_markdown's rendering
+    contextual_text: str       # text with [Section], [Page], [Type] tags
+    content_hash: str          # lazy sha256 of whitespace-normalized text
+    metadata: ChunkMetadata
+```
+
+### ChunkMetadata
+
+```python
+ChunkMetadata:
+    page_start, page_end: int  # 1-based original page numbers (survive pages=)
+    element_ids: list[str]     # ["p1.b0", ...] — evidence addresses
+    section_path: list[str]    # citation path = the owning section's path
+    section_id: str | None     # innermost section ("s{n}")
+    table_ids: list[str]       # tables in this chunk ("t{n}")
+    figure_ids: list[str]      # figures in this chunk ("f{n}")
+    chunk_type: str            # "paragraph", "table", "list", "figure", ... (chunk_type_hint is a read-only alias)
+    chunk_types: list[str]     # all types present
+    bboxes: list[tuple]        # (page, x0, y0, x1, y1)
+    lists: list[dict]          # logical list groups
+    token_count: int           # per-chunk token count
+    ocr: bool                  # True when a source page went through OCR
+    file_path, page_count
+```
+
+### Views
+
+```python
+TableChunk:   id, chunk_id, element_id, page, bbox,
+              markdown | html   # mutually exclusive by parse mode
+              headers           # header cell texts from <th>; [] on markdown parses
+              caption, caption_element_id
+              section_id        # innermost section ("s{n}")
+              token_count
+              text              # canonical rendering for the parse mode
+
+FigureChunk:  id, chunk_id, element_id, page, bbox, boxclass,
+              ocr_text          # extracted text; None → OCR candidate
+              placeholder       # "[Figure f{n}: WxH]" when there's no text
+              caption, caption_element_id
+              section_id        # innermost section ("s{n}")
+              image             # bytes when extract_images=True
+              has_text          # bool(ocr_text and ocr_text.strip())
+
+SectionChunk: id, title, level, page_start, page_end,
+              heading_element_id
+              path              # titles, root → self
+              element_span      # [start, end) into ChunkedDocument.elements
+              child_chunk_ids   # chunks under this section
+              token_count       # sum over child chunks
+              text              # lazy, assembled from the element registry
+```
+
+`TableChunk.markdown` is never backfilled with HTML: in HTML table mode
+the parser carries `markdown=None` and `html` is canonical; on markdown
+parses `html is None` and `headers == []` (header identity comes only
+from the engine's `<th>`, never from local heuristics).
+
+**Sections have a single source of truth**: the layout-detected heading
+boxes (`section-header`/`title`). The `sections` view, `hierarchy`, and
+`chunk.metadata.section_path` (= the innermost owning section's `path`)
+all derive from that same heading walk — the PDF TOC is never consulted,
+so a document without bookmarks still gets a fully populated
+`section_path`, always consistent with the views. Chunk boundaries also
+respect this structure: with `respect_section_starts=True` (default) a
+section-opening chunk is never budget-merged into the previous section's
+tail.
+
+**Sections nest.** `SectionChunk.level` is the engine's font-statistics
+heading level — the same value the renderers use for `#`/`##`/`###`
+depth — so big headings contain small ones: a level-4 section's `path`
+carries all its ancestors (`["Paper Title", "…", "AUTHOR INFORMATION",
+"Corresponding Author"]`), and `cd.hierarchy` exposes the same nesting
+as a `SectionNode` tree (root level 0). The section tree therefore
+always matches the heading depth visible in the rendered markdown.
+
+A real document makes the ownership rules concrete (a 21-page slice of
+the ISO 32000-2 specification, abridged; `own` = chunks whose
+`section_id` is this section, `subtree` = the rollup):
+
+```
+s0 L1 'International Standard ISO 32000-2'  own=[c1]      subtree=36ch/12,953tok
+└─ s1 L2 'ISO 32000-2'                      own=[c2]      subtree=35ch/12,813tok
+   ├─ s2 L6 'COPYRIGHT PROTECTED DOCUMENT'  own=[c3]      (heading-only)
+   ├─ s4 L4 'Foreword'                      own=[c9,c10]
+   ├─ s5 L4 'Introduction'                  own=[c11]     subtree=13ch/3,454tok
+   │  ├─ s6 L5 '0.1 PDF'                    own=[c12–c14]
+   │  └─ s9 L5 '0.4 Changes introduced …'   own=[c21–c23]
+   └─ s10 L3 'Document management — …'      own=[c24]     (L5 → L3: stack pops back)
+      └─ s11 L4 '1 Scope'                   own=[c25]
+```
+
+- **Ownership is innermost.** Content attaches at whatever depth it
+  appears (chunks above sit at L3, L4, L5, and L6): a paragraph after
+  `0.1 PDF` gets `section_id="s6"` and
+  `section_path=[…, "Introduction", "0.1 PDF"]` — one unambiguous
+  address per chunk.
+- **Heading-only sections** still exist in the tree, owning just their
+  own heading chunk (s2) until a same-or-shallower heading closes them.
+  A parent like s5 "Introduction" similarly owns only its heading chunk
+  while the content lives in its child sections.
+- **Ancestors aggregate.** `child_chunk_ids` and `token_count` cover
+  the whole subtree (s5 rolls up 13 chunks / 3,454 tokens), and
+  `element_span`s nest: s5 `(58, 219)` contains s6 `(59, 88)` — feed a
+  whole branch to an LLM via `SectionChunk.text`.
+- **Before the first heading**, chunks stay unowned: `section_id=None`,
+  `section_path=[]` (a cover-page figure, for instance).
+
+## Cookbook
+
+Every snippet below runs as-is against the repo's example document —
+six pages of capital-city tables. Output lines (`# ->`) are real,
+captured on pymupdf 1.28.2:
+
+```python
+cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf")
+# -> len(cd) == 6
+# c0: type='table' tokens=351 elements=['p1.b0', 'p1.b1', 'p1.b2']
+# c1: type='table' tokens=377 elements=['p2.b0']
+# ...
+```
+
+### 1. Embed with context
+
+```python
+for c in cd:
+    embed(c.contextual_text)   # includes section path + page + type tags
+
+# c0.contextual_text ->
+# [Section] World Capital Cities
+# [Page] 1
+# [Type] heading, table
+# [Content]
+# # **World Capital Cities**
+# _Percent "%" is city population as a percentage of the country, ..._
+```
+
+(`[Section]` comes from the layout-detected heading structure — this
+document has no PDF bookmarks, and none are needed.)
+
+### 2. Ingestion gate wiring
+
+`cd.diagnostics` is the machine-readable input for a PROCEED/HOLD/REJECT
+decision — it reports facts; your pipeline owns the thresholds. This is
+how you catch "a perfectly fine document quietly produced 0 chunks"
+before it poisons an index:
+
+```python
+d = cd.diagnostics
+# -> {"chunk_count": 6, "element_count": 14, "table_count": 6,
+#     "figure_count": 0, "section_count": 1, "page_count": 6,
+#     "pages_without_chunks": [], "zero_chunk_causes": [],
+#     "figures_without_text": [], "degenerate_tables": [],
+#     "header_footer_excluded": 6}
+
+if d["chunk_count"] == 0:
+    verdict = ("REJECT", d["zero_chunk_causes"])          # nothing usable
+elif d["pages_without_chunks"] or d["degenerate_tables"]:
+    verdict = ("HOLD", {"pages": d["pages_without_chunks"],
+                        "tables": d["degenerate_tables"]})  # human review
+elif d["figures_without_text"]:
+    verdict = ("PROCEED_WITH_OCR_QUEUE", d["figures_without_text"])
+else:
+    verdict = ("PROCEED", None)
+# -> ("PROCEED", None)
+```
+
+### 3. Idempotent vector-store upserts
+
+Assemble the point id from stable scopes; re-ingesting the same document
+version then *updates* instead of duplicating. Keep ids for machines and
+citations (`section_path`, pages) for humans — never show a point id to a
+user, never parse a citation back into an id:
+
+```python
+def point_id(c, *, tenant, kb, doc_id, emb_ver):
+    return f"{tenant}:{kb}:{doc_id}:{c.metadata.page_start}:{c.id}:{emb_ver}"
+# point_id(cd[0], tenant="acme", kb="manuals", doc_id="9f2d...",
+#          emb_ver="e5-large-v2")
+# -> "acme:manuals:9f2d...:1:c0:e5-large-v2"
+# citation -> {"section": "World Capital Cities", "pages": [1, 1]}
+
+for c, payload in zip(cd, cd.to_dicts()):
+    store.upsert(id=point_id(c, tenant="acme", kb="manuals",
+                             doc_id=sha, emb_ver="e5-large-v2"),
+                 vector=embed(c.contextual_text),
+                 payload=payload | {"citation": {
+                     "section": " > ".join(c.metadata.section_path),
+                     "pages": [c.metadata.page_start, c.metadata.page_end]}})
+```
+
+Treat the assembly rule as immutable code: changing it re-keys the whole
+collection.
+
+### 4. Change detection / dedup with content_hash
+
+```python
+prev = {r["id"]: r["content_hash"] for r in previous_ingest}
+changed = [c for c in cd if prev.get(c.id) != c.content_hash]
+re_embed(changed)              # first stage of multi-stage dedup
+
+# cd[0].content_hash -> "6adc89bfaeef7db4..." (sha256, whitespace-normalized)
+# unchanged document -> changed == []
+```
+
+### 5. Tables and figures as first-class citations
+
+```python
+for t in cd.tables:
+    index_table(t.id, t.text, headers=t.headers,
+                cite=(t.page, t.bbox), context_chunk=cd.get(t.chunk_id).text)
+# t0: chunk=c0 page=1 text starts
+#     "|**Country**|**Capital**|**Population**|**%**|**Year**|"
+
+for f in cd.figures:
+    if not f.has_text:
+        ocr_queue.append((f.id, f.page, f.bbox))   # from diagnostics too
+```
+
+For header-aware table retrieval, parse with
+`to_chunks("doc.pdf", table_output="html")`: `t.text` becomes the engine's
+HTML (colspan/rowspan preserved) and `t.headers` carries the `<th>` cell
+texts — but only when the engine's header detection fires; otherwise
+`headers` stays `[]`, exactly as on markdown parses. Captured from the
+repo's `tests/test_sce_150_1.pdf`:
+
+```python
+cd = pymupdf4llm.to_chunks("tests/test_sce_150_1.pdf", table_output="html")
+# t1: markdown=None, "<th" in t1.html,
+#     headers=['Alternate Calculation with Reinsurance', '', '', '']
+```
+
+### 6. Retrieval-time context expansion
+
+Chunks are ordered; position replaces stored neighbor links:
+
+```python
+hit = cd.get("c1")
+i = int(hit.id[1:])
+window = cd[max(0, i - 2): i + 3]
+# -> [c0, c1, c2, c3]  (clamped at document edges)
+```
+
+### 7. Budget tuning without re-parsing
+
+Different budgets serve different consumers — the default 400 targets
+embedding-model inputs; 800–1200 suits rerankers and long-context
+synthesis; ~2000 suits section-first keyword retrieval (recipe 9). One
+parse serves them all:
+
+```python
+cd = pymupdf4llm.to_chunks("big.pdf")          # parse once
+for budget in (200, 400, 800):
+    evaluate(cd.reassemble_chunks(max_tokens=budget))    # milliseconds each
+# on the 6-page example: 200 -> 7 chunks, 400 -> 6, 800 -> 3, ~1 ms each
+```
+
+Measured on a 1,003-page reference PDF (pymupdf 1.28.2): parse ~36 min
+once, then `reassemble_chunks()` 0.7–1.2 s per budget — three orders of magnitude
+cheaper than re-parsing per configuration.
+
+### 8. Small-to-big retrieval
+
+Search precisely over small chunks, feed the LLM the surrounding big
+chunk. Both granularities come from the same parse and share element
+addresses, so the mapping is a set intersection — no extra bookkeeping:
+
+```python
+cd = pymupdf4llm.to_chunks("doc.pdf")          # small: 400 tok, indexed
+big = cd.reassemble_chunks(max_tokens=1200)              # big: LLM context
+
+hit = search(query)                            # returns a small chunk id
+small = cd.get(hit)
+context = next(b for b in big
+               if set(small.metadata.element_ids)
+                  & set(b.metadata.element_ids))
+answer = llm(query, context.text)
+# on the example: hit c1 (377 tok) -> big c0 (1,093 tok, pages 1-3)
+```
+
+### 9. Section-first chunking for keyword / non-embedding retrieval
+
+BM25-style and navigational retrieval usually wants section-shaped
+units around ~2000 tokens rather than embedding-sized ones. Large
+budgets keep section purity because a section-opening chunk never
+budget-merges backward (`respect_section_starts=True`, the default):
+
+```python
+cd = pymupdf4llm.to_chunks("paper.pdf")
+big = cd.reassemble_chunks(max_tokens=2000)
+by_section = {}
+for c in big:
+    by_section.setdefault(c.metadata.section_id, []).append(c)
+# tests/test_370.pdf (7 sections) -> 8 chunks, each inside one section:
+#   s0: [c0]  s1: [c1, c2]  s2: [c3]  s3: [c4] ...
+# with respect_section_starts=False -> 3 chunks, sections glued together
+```
+
+Index each entry under `" > ".join(chunk.metadata.section_path)` for
+navigable, citable results.
+
+The sections view itself is often the better keyword-search unit. A
+chunk hit can be a heading-only chunk (a subheading followed directly
+by its own subheading carries no body text), but a section is never
+under-evidenced: `SectionChunk.text` lazily assembles the section's
+whole subtree — its heading plus every child section's content — and
+`token_count` is the subtree rollup, so oversized branches are easy to
+filter before indexing:
+
+```python
+for s in cd.sections:
+    if s.token_count <= 4000:            # whole subtree fits the budget
+        keyword_index(s.id, s.text, path=" > ".join(s.path))
+
+# or expand a chunk hit to its owning section at query time:
+hit = cd.get("c11")                      # '#### **Introduction**', 5 tok
+evidence = cd.get(hit.metadata.section_id).text
+# ISO 32000-2 slice -> the 'Introduction' section text: its heading plus
+# all of 0.1-0.4, 3,454 tokens - sufficient grounds instead of one line
+```
+
+### 10. Framework export
+
+```python
+docs = cd.to_langchain_documents()   # needs langchain-core
+nodes = cd.to_llama_nodes()          # needs llama-index-core
+# -> 6 Documents / 6 TextNodes; docs[0].page_content == cd[0].text,
+#    metadata keys: bboxes, chunk_type, chunk_types, element_ids, ...
+```
+
+## contextual_text Format
+
+```
+[Section] Chapter 1 > Section 1.2
+[Page] 5
+[Type] table
+[Content]
+{chunk.text}
+```
+
+- `[Section]` appears only when `section_path` is non-empty.
+- `[Type]` appears only when the type is not `"paragraph"`.
+
+## Token counting
+
+Chunk budgets sum precomputed per-unit token counts (no re-tokenizing of
+joined text). The sum may differ from tokenizing the final chunk text by
+at most the number of unit joins — budgets are targets, not guarantees.
+Pass `tokenizer="cl100k_base"` (tiktoken) or a callable for exact counts
+per unit; the default is a 4-chars-per-token estimate. An unknown tiktoken
+encoding name raises `ValueError` rather than silently falling back.
+
+The resulting total is exposed as `metadata.token_count`, and on the
+`TableChunk` / `SectionChunk` views as `token_count`.

--- a/CHUNKING.md
+++ b/CHUNKING.md
@@ -50,13 +50,14 @@ raise `TypeError`.
 
 ## At a Glance
 
-One slow layout extraction feeds one reusable substrate; everything
+One slow layout extraction feeds one reusable set of parsed layout
+data; everything
 downstream — assembly, views, exports, re-chunking — is cheap:
 
 ```mermaid
 flowchart LR
     pdf["PDF"] -->|"parse parameters<br/>slow · runs once"| parse["parse_document()<br/>layout extraction"]
-    parse --> sub["substrate<br/>element registry + units"]
+    parse --> sub["parsed layout<br/>element registry + units"]
     sub -->|"chunk parameters<br/>fast"| asm["assembly"]
     asm --> cd["ChunkedDocument"]
     cd --> chunks["chunks<br/>text == to_markdown"]
@@ -66,7 +67,7 @@ flowchart LR
 ```
 
 The two parameter tiers below map onto the two arrows: parse parameters
-change the substrate (re-parse required), chunk parameters only change
+change the parsed layout (re-parse required), chunk parameters only change
 assembly (`reassemble_chunks()` is enough).
 
 Assembly itself works in stages. Layout signals (box boundaries, box
@@ -104,15 +105,16 @@ Passed to `parse_document()` internally.
 | `edge_threshold` | `None` | Layout GNN edge-probability cut for box grouping (engine default 0.55; lower merges more, higher fragments more) |
 | `show_progress` | `False` | Show progress bar |
 
-`table_output` and `edge_threshold` are substrate options: `reassemble_chunks()`
-rejects them — re-parse via `to_chunks()` to change them.
+`table_output` and `edge_threshold` change the parsed layout itself, so
+`reassemble_chunks()` rejects them; re-parse via `to_chunks()` to change
+them.
 
 ### Chunk Parameters
 
 | Parameter | Default | Description |
 |---|---|---|
-| `max_tokens` | `400` | Maximum tokens per chunk. The default targets embedding-model inputs; larger budgets (800–2000) suit long-context synthesis, rerankers, and section-first keyword retrieval — see recipes 5 and 6 |
-| `min_tokens` | `120` | Minimum tokens (merge threshold) |
+| `max_tokens` | `400` | Target tokens per chunk. The default is a starting point sized for common embedding inputs; larger budgets are typical for long-context synthesis or section-shaped retrieval — compare sizes with recipe 5 and check final inputs against your model's tokenizer |
+| `min_tokens` | `120` | Budget-merge floor: neighbouring chunks combine only while one of them is below this size. `0` disables the floor; `min_tokens=max_tokens` packs greedily up to the budget |
 | `breakpoint_threshold` | `0.5` | Boundary score threshold for splitting |
 | `merge_small_chunks` | `True` | Merge undersized chunks with neighbors |
 | `table_mode` | `"preserve"` | `"preserve"`: table = one chunk; `"isolate"`: tables never budget-merge |
@@ -128,19 +130,17 @@ time: `ChunkedDocument.to_dicts()` / `.to_json()` take a keyword-only
 
 ### Choosing a budget
 
-The 400-token default sits in the evidence-supported band for
-general-purpose retrieval: chunking ablations find ~200 tokens best for
-precision-oriented fact QA and 512–1024 for synthesis/analytical tasks,
-with both extremes losing (Chroma, *Evaluating Chunking Strategies*;
-NVIDIA, *Finding the Best Chunking Strategy*, 2025). Long-context
-embedding models did not move this — their windows go to context
-conditioning (late chunking, contextualized chunk embeddings), not to
-bigger retrieval units. Layout-aware boundaries matter more than the
-exact number (structure-based splitting beats size tuning in 2025–26
-studies), and on layout-rich documents only ~10–40% of chunks hit the
-budget cap at all — the rest end at headings, tables, and boxes. When a
-different consumer needs a different size, `reassemble_chunks()` is the intended
-answer (recipes 5 and 6), not a changed default.
+The 400-token default is a starting point, not a recommendation for
+every task: published chunking ablations (Chroma, *Evaluating Chunking
+Strategies*; NVIDIA, *Finding the Best Chunking Strategy*, 2025) place
+useful sizes for retrieval roughly between ~200 and ~1024 tokens
+depending on the task and the embedding model, and report that
+structure-aware boundaries matter more than the exact number. On
+layout-rich documents most chunk boundaries here come from headings,
+tables, and boxes rather than from the budget cap. Evaluate candidate
+sizes on your own corpus and retrieval task; `reassemble_chunks()`
+exists so that comparison costs seconds instead of a re-parse (recipes
+5 and 6).
 
 ## IDs Are a Contract
 
@@ -202,16 +202,17 @@ cd.to_dicts(include_tagged=False)   # drop tagged_content from the payload
 
 # Re-chunking, diagnostics, provenance
 cd.reassemble_chunks(max_tokens=200)   # new ChunkedDocument from retained units, no re-parse
-cd.diagnostics                 # dict for an ingestion gate (keys below)
+cd.diagnostics                 # extraction checks before indexing (keys below)
 cd.params                      # read-only mapping of the parameters cd was built with
 ```
 
 `reassemble_chunks()` accepts assembly-tier parameters only (`max_tokens`,
 `min_tokens`, `breakpoint_threshold`, `table_mode`, `merge_small_chunks`,
-`respect_section_starts`). Substrate parameters (`sentence_splitter`,
-`header_footer_mode`, `tokenizer`, `weights`) and parse options raise
-`ValueError` — call `to_chunks()` on a new parse instead. It returns a new
-`ChunkedDocument`; the original is unchanged.
+`respect_section_starts`). The remaining parameters (`sentence_splitter`,
+`header_footer_mode`, `tokenizer`, `weights`) and parse options change
+the parsed layout data itself and raise `ValueError` — call `to_chunks()`
+on a new parse instead. It returns a new `ChunkedDocument`; the original
+is unchanged.
 
 ### Chunk
 
@@ -237,7 +238,7 @@ ChunkMetadata:
     types: list[str]           # element types present, in order:
                                # "heading", "paragraph", "table", "list", "figure", "caption", ...
     bboxes: list[tuple]        # (page, x0, y0, x1, y1)
-    lists: list[dict]          # logical list groups
+    lists: list[dict]          # list groups: {"items": [{text, page, bbox}], "bboxes": [(page, ...)]}
     token_count: int           # per-chunk token count
     ocr: bool                  # True when a source page went through OCR
     file_path, page_count
@@ -266,9 +267,9 @@ One dict per chunk; `metadata` carries every `ChunkMetadata` field as-is:
 
 ### diagnostics
 
-`cd.diagnostics` reports facts about the parse for an ingestion gate; your
-pipeline owns the thresholds (recipe 2). Values shown are for the example
-document:
+`cd.diagnostics` reports facts about the parse so you can check
+extraction results before indexing; your pipeline owns the thresholds
+(recipe 2). Values shown are for the example document:
 
 ```text
 {
@@ -359,13 +360,13 @@ for s in cd_p.sections:
 ```
 
 ```text
-s0 L1 'Synthesis of Silyl Die' own=['c0'] subtree=21ch/4711tok
-   s1 L2 'Masahiro Sai' own=['c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8', 'c9', 'c10'] subtree=20ch/4688tok
-      s2 L3 'AUTHOR INFORMATION' own=['c11'] subtree=3ch/43tok
-         s3 L4 'Corresponding Author' own=['c12'] subtree=1ch/21tok
-         s4 L4 'Notes' own=['c13'] subtree=1ch/16tok
-      s5 L3 'ACKNOWLEDGMENT' own=['c14'] subtree=1ch/24tok
-      s6 L3 'REFERENCES' own=['c15', 'c16', 'c17', 'c18', 'c19', 'c20'] subtree=6ch/1637tok
+s0 L1 'Synthesis of Silyl Die' own=['c0'] subtree=22ch/4711tok
+   s1 L2 'Masahiro Sai' own=['c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8', 'c9', 'c10', 'c11'] subtree=21ch/4688tok
+      s2 L3 'AUTHOR INFORMATION' own=['c12'] subtree=3ch/43tok
+         s3 L4 'Corresponding Author' own=['c13'] subtree=1ch/21tok
+         s4 L4 'Notes' own=['c14'] subtree=1ch/16tok
+      s5 L3 'ACKNOWLEDGMENT' own=['c15'] subtree=1ch/24tok
+      s6 L3 'REFERENCES' own=['c16', 'c17', 'c18', 'c19', 'c20', 'c21'] subtree=6ch/1637tok
 ```
 
 `s5` shows the stack popping back: after the level-4 `Notes`, a level-3
@@ -373,15 +374,15 @@ heading closes both `s4` and `s2` and becomes a sibling of `s2`.
 
 - **Ownership is innermost.** Content attaches at whatever depth it
   appears: the `Corresponding Author` heading and the e-mail line under
-  it form chunk `c12` with `section_id="s3"` and
+  it form chunk `c13` with `section_id="s3"` and
   `section_path=[..., "AUTHOR INFORMATION", "Corresponding Author"]`,
   one unambiguous address per chunk.
 - **Heading-only sections** still exist in the tree, owning just their
-  own heading chunk (`s2` owns `c11`, the 6-token `### **AUTHOR
+  own heading chunk (`s2` owns `c12`, the 6-token `### **AUTHOR
   INFORMATION**` line) until a same-or-shallower heading closes them;
   the content lives in the child sections `s3` and `s4`.
 - **Ancestors aggregate.** `child_chunk_ids` and `token_count` cover the
-  whole subtree (`s2` rolls up `["c11", "c12", "c13"]`, 43 tokens), and
+  whole subtree (`s2` rolls up `["c12", "c13", "c14"]`, 43 tokens), and
   `element_span`s nest: `s2` `(34, 39)` contains `s3` `(35, 37)`. Feed a
   whole branch to an LLM via `SectionChunk.text` (recipe 6).
 - **Before the first heading**, chunks stay unowned: `section_id=None`,
@@ -391,316 +392,282 @@ heading closes both `s4` and `s2` and becomes a sibling of `s2`.
 
 ## Cookbook
 
-The recipes below are for people building a retrieval pipeline on top of
-`to_chunks()`. Each one runs as-is from the repository root against a PDF
-shipped with the repository, and every `# ->` line is real output
-captured on pymupdf 1.28.2.
+These examples show how to prepare chunks for search, inspect extraction
+results, and add context to search results. Run the setup below from the
+repository root before using a recipe. Each recipe then stands on its own.
+Recipe 7 also requires the framework packages it uses.
 
-**Reader-side placeholders.** The recipes need things pymupdf4llm does
-not provide: an embedding model, a vector store, a keyword index, a
-retriever, an LLM. Each recipe defines the ones it needs as tiny stand-in
-stubs between a `# --- your code: ... ---` and a `# --- end of your code ---`
-comment; replace those with your own implementations. Everything outside
-those markers is pymupdf4llm API: every attribute or method called on
-`cd`, on a chunk, or on a table/figure/section view is documented in the
-sections above.
-
-`cd` in the recipes is the example document, six pages of capital-city
-tables; recipes that use another PDF parse it themselves:
+The examples build ordinary Python dictionaries and lists. Connect these
+to your own embedding model, search index, or application as needed.
 
 ```python
+from pathlib import Path
+from hashlib import sha256
+
 import pymupdf4llm
 
-cd = pymupdf4llm.to_chunks("examples/country-capitals/national-capitals.pdf")
-for c in cd:
-    print(c.id, c.metadata.types, c.metadata.token_count, c.metadata.element_ids)
-# -> c0 ['heading', 'paragraph', 'table'] 351 ['p1.b0', 'p1.b1', 'p1.b2']
-#    c1 ['table'] 377 ['p2.b0']
-#    c2 ['table'] 365 ['p3.b0']
-#    c3 ['table'] 373 ['p4.b0']
-#    c4 ['table'] 399 ['p5.b0']
-#    c5 ['table'] 369 ['p6.b0']
+pdf_path = "examples/country-capitals/national-capitals.pdf"
+cd = pymupdf4llm.to_chunks(pdf_path, max_tokens=400)
 ```
 
-### 1. Embed with context and upsert with stable ids
+### 1. Prepare chunks for indexing
 
-Embed `tagged_content`, not `text`: it prefixes the section path, page
-and element types, so the vector carries where the chunk sits in the
-document. `[Section]` comes from the layout-detected heading structure;
-this document has no PDF bookmarks, and none are needed.
+Use `chunk.text` for the extracted Markdown. Use `chunk.tagged_content`
+when you also want section titles, page numbers, and content types in
+the text sent to your embedding model. Choose the input that works best
+for your retrieval task, and apply any formatting your model requires.
+
+Chunk IDs such as `c0` belong to one `ChunkedDocument`. For a shared
+index, combine them with a document ID, document version, and processing
+version. The processing version should identify the package versions,
+parse options, chunk settings, and embedding setup you used.
 
 ```python
-print(cd[0].tagged_content[:130])
-# -> [Section] World Capital Cities
-#    [Page] 1
-#    [Type] heading, table
-#    [Markdown]
-#    # **World Capital Cities**
-#    _Percent "%" is city population
+document_id = "national-capitals"
+document_version = sha256(Path(pdf_path).read_bytes()).hexdigest()
+index_version = "layout-400-v1"        # your processing configuration version
+embedding_config = "my-model-v1"      # include model and input-format settings
+
+records = {}
+for chunk, payload in zip(cd, cd.to_dicts()):
+    record_id = f"{document_id}:{document_version}:{index_version}:{chunk.id}"
+    embedding_text = chunk.tagged_content
+    records[record_id] = {
+        **payload,
+        "embedding_text": embedding_text,
+        "embedding_config": embedding_config,
+        "embedding_input_hash": sha256(embedding_text.encode("utf-8")).hexdigest(),
+        "citation": {
+            "section": " > ".join(chunk.metadata.section_path),
+            "pages": [chunk.metadata.page_start, chunk.metadata.page_end],
+        },
+    }
+
+print(len(records))
 ```
 
-Assemble the vector-store point id from stable scopes; re-ingesting the
-same document version then *updates* instead of duplicating. Keep ids for
-machines and citations (`section_path`, pages) for humans: never show a
-point id to a user, never parse a citation back into an id. Treat the id
-assembly rule as immutable code, since changing it re-keys the whole
-collection.
+Send each record's `embedding_text` to your model, then save the returned
+vector with the record's ID and metadata. Adding a record with an existing
+ID should replace that record. Some databases call this operation `upsert`.
+
+To reuse an existing embedding, compare both `embedding_config` and
+`embedding_input_hash` with the values saved previously. Hash the exact
+text sent to the model, after adding any required prefix or other formatting.
+`chunk.content_hash` covers only whitespace-normalized `chunk.text`, so it
+does not detect changes to the section or page information in
+`tagged_content`. Refresh citation metadata even when an embedding is reused.
+
+When replacing a document in your index, also remove its previous records
+that are no longer current. Saving new records alone does not remove old
+chunks after a document or configuration change. If you retain multiple
+versions, search only the version you intend to use.
+
+### 2. Check extraction results before indexing
+
+`cd.diagnostics` lists potential gaps in the extracted content. Use these
+details to decide whether to index the document, inspect it, or request OCR.
+An empty page or a figure without text may be expected, so adapt the checks
+to your documents.
 
 ```python
-# --- your code: replace with your embedding model and vector store ---
-def embed(text):
-    return [0.0] * 8                 # stand-in for an embedding vector
+diagnostics = cd.diagnostics
 
-class VectorStore:
-    def __init__(self):
-        self.points = {}
+if diagnostics["chunk_count"] == 0:
+    print("No chunks to index:", diagnostics["zero_chunk_causes"])
+else:
+    print("Chunks available:", diagnostics["chunk_count"])
 
-    def upsert(self, id, vector, payload):
-        self.points[id] = (vector, payload)
-
-store = VectorStore()
-doc_id = "9f2d"                      # your document identity, e.g. sha256 of the file bytes
-# --- end of your code ---
-
-def point_id(c, *, tenant, kb, doc_id, emb_ver):
-    return f"{tenant}:{kb}:{doc_id}:{c.metadata.page_start}:{c.id}:{emb_ver}"
-
-for c, payload in zip(cd, cd.to_dicts()):
-    store.upsert(
-        id=point_id(c, tenant="acme", kb="manuals", doc_id=doc_id, emb_ver="e5-large-v2"),
-        vector=embed(c.tagged_content),
-        payload={**payload, "citation": {
-            "section": " > ".join(c.metadata.section_path),
-            "pages": [c.metadata.page_start, c.metadata.page_end]}},
-    )
-
-pid = point_id(cd[0], tenant="acme", kb="manuals", doc_id=doc_id, emb_ver="e5-large-v2")
-print(pid)
-# -> acme:manuals:9f2d:1:c0:e5-large-v2
-print(store.points[pid][1]["citation"])
-# -> {'section': 'World Capital Cities', 'pages': [1, 1]}
+if diagnostics["pages_without_chunks"]:
+    print("Check these pages:", diagnostics["pages_without_chunks"])
+if diagnostics["degenerate_tables"]:
+    print("Check these empty tables:", diagnostics["degenerate_tables"])
+if diagnostics["figures_without_text"]:
+    print("Figures to consider for OCR:", diagnostics["figures_without_text"])
 ```
 
-On re-ingest, `content_hash` (sha256 of whitespace-normalized chunk text)
-tells you which chunks actually changed, so only those are re-embedded:
+### 3. Retrieve and cite tables and figures
 
-```python
-# --- your code: content hashes stored by the previous ingest, keyed by chunk id ---
-previous = {c.id: c.content_hash for c in cd}      # here: the same document, unchanged
-# --- end of your code ---
-
-changed = [c for c in cd if previous.get(c.id) != c.content_hash]
-print(len(changed), cd[0].content_hash[:16])
-# -> 0 6adc89bfaeef7db4
-```
-
-### 2. Ingestion gate wiring
-
-`cd.diagnostics` is the machine-readable input for a PROCEED/HOLD/REJECT
-decision. It reports facts; your pipeline owns the thresholds. This is
-how you catch "a perfectly fine document quietly produced 0 chunks"
-before it poisons an index:
-
-```python
-def gate(d):
-    """Verdict from cd.diagnostics; the rules are yours to tune."""
-    if d["chunk_count"] == 0:
-        return "REJECT", d["zero_chunk_causes"]                 # nothing usable
-    if d["pages_without_chunks"] or d["degenerate_tables"]:
-        return "HOLD", {"pages": d["pages_without_chunks"],
-                        "tables": d["degenerate_tables"]}      # human review
-    if d["figures_without_text"]:
-        return "PROCEED_WITH_OCR_QUEUE", d["figures_without_text"]
-    return "PROCEED", None
-
-print(cd.diagnostics)
-# -> {'chunk_count': 6, 'element_count': 14, 'table_count': 6, 'figure_count': 0,
-#     'section_count': 1, 'page_count': 6, 'pages_without_chunks': [],
-#     'zero_chunk_causes': [], 'figures_without_text': [], 'degenerate_tables': [],
-#     'header_footer_excluded': 6}
-print(gate(cd.diagnostics))
-# -> ('PROCEED', None)
-```
-
-### 3. Tables and figures as first-class citations
-
-`cd.tables` and `cd.figures` give every table and figure its own id, page
-and bbox, plus the chunk that holds it, so they can be indexed and cited
-on their own. `tests/test_tablulate_bug.pdf` is a one-page document with
-two tables and two figures:
+Tables and figures have their own IDs and source locations. This lets you
+index a table separately while keeping its surrounding chunk as context,
+or locate a figure that may need OCR.
 
 ```python
 cd_t = pymupdf4llm.to_chunks("tests/test_tablulate_bug.pdf")
-print(cd_t)
-# -> ChunkedDocument(chunks=4, tables=2, figures=2, sections=4)
 
-# --- your code: replace with your table index and OCR queue ---
-table_index = {}
-ocr_queue = []
-# --- end of your code ---
+table_records = {}
+for table in cd_t.tables:
+    table_records[table.id] = {
+        "text": table.text,
+        "headers": table.headers,
+        "page": table.page,
+        "bbox": table.bbox,
+        "context": cd_t.get(table.chunk_id).text,
+    }
 
-for t in cd_t.tables:
-    table_index[t.id] = {"text": t.text, "headers": t.headers,
-                         "cite": (t.page, t.bbox),
-                         "context": cd_t.get(t.chunk_id).text}   # the whole owning chunk
-    print(t.id, t.chunk_id, t.page, t.headers, t.text[:27])
-# -> t0 c1 1 [] |**Targets**|**Weighting**|
-#    t1 c3 1 [] ||||||||**Total value of**|
+figures_to_check = [
+    {"id": figure.id, "page": figure.page, "bbox": figure.bbox}
+    for figure in cd_t.figures
+    if not figure.has_text
+]
 
-for f in cd_t.figures:
-    if not f.has_text:                                        # no extractable text
-        ocr_queue.append((f.id, f.page, f.bbox))
-print(ocr_queue)
-# -> [('f1', 1, (758.0, 152.0, 1021.0, 265.0)), ('f2', 1, (758.0, 336.0, 1021.0, 372.0))]
-print(cd_t.diagnostics["figures_without_text"])
-# -> ['f1', 'f2']      (the same ids, if you prefer to read them from diagnostics)
+print(table_records.keys())
+print(figures_to_check)
 ```
 
-For header-aware table retrieval, parse with `table_output="html"`:
-`t.text` becomes the engine's HTML (colspan/rowspan preserved) and
-`t.headers` carries the `<th>` cell texts, but only when the engine's
-header detection fires; otherwise `headers` stays `[]`, exactly as on
-markdown parses:
+The IDs in these local dictionaries also need document and version scopes
+before being used in a shared index, as in recipe 1.
+
+Use `table_output="html"` when you need HTML table structure, including
+merged cells. On a supported engine, `table.text` contains the HTML and
+`table.headers` contains any cells detected as headers. Header lists may
+still be empty. Engines without HTML table support fall back to Markdown.
 
 ```python
 cd_h = pymupdf4llm.to_chunks("tests/test_sce_150_1.pdf", table_output="html")
-t1 = cd_h.get("t1")
-print(t1.markdown, "<th" in t1.html, t1.headers)
-# -> None True ['Alternate Calculation with Reinsurance', '', '', '']
+for table in cd_h.tables:
+    print(table.id, table.headers, table.text[:100])
 ```
 
-### 4. Context window around a hit
+### 4. Add neighboring chunks to a search result
 
-A `ChunkedDocument` is a list in reading order, so the chunks around a
-search hit are just a slice around its position. Nothing is stored per
-chunk for this; `c{n}` is the position, and `cd.index()` gives it for a
-chunk object.
+A `ChunkedDocument` is a sequence in reading order. Given a chunk ID
+returned by your search, select nearby chunks to provide more context.
+This example uses `c3` as the search result.
 
 ```python
-hit = cd.get("c3")                    # the chunk id your search returned
-i = cd.index(hit)                     # 3
-window = cd[max(0, i - 2): i + 3]     # two before, the hit, two after
-print([c.id for c in window])
-# -> ['c1', 'c2', 'c3', 'c4', 'c5']
+hit = cd.get("c3")
+position = cd.index(hit)
+neighbors = cd[max(0, position - 2):position + 3]
+context = "\n\n".join(chunk.text for chunk in neighbors)
 
-edge = cd[max(0, 0 - 2): 0 + 3]       # a hit on c0: the slice simply clamps
-print([c.id for c in edge])
-# -> ['c0', 'c1', 'c2']
+print([chunk.id for chunk in neighbors])
+print(context[:200])
 ```
 
-### 5. Budget tuning and small-to-big retrieval
+This includes up to two chunks before and after the hit. The slice stops
+at the document edges; it may cross section boundaries. Use recipe 6
+when you want context from the hit's section instead.
 
-Different budgets serve different consumers: the default 400 targets
-embedding-model inputs; 800–1200 suits rerankers and long-context
-synthesis; ~2000 suits section-first keyword retrieval (recipe 6).
-`reassemble_chunks()` re-runs assembly from the retained units, so one
-parse serves them all:
+### 5. Compare chunk sizes and expand search results
+
+`reassemble_chunks()` creates new chunks from the layout already extracted.
+You can compare sizes without parsing the PDF again. Choose a size based
+on your retrieval results and the model's input limit.
 
 ```python
 for budget in (200, 400, 800):
-    print(budget, len(cd.reassemble_chunks(max_tokens=budget)))
-# -> 200 7
-#    400 6
-#    800 3        (about a millisecond each; no re-parse)
+    candidate = cd.reassemble_chunks(max_tokens=budget)
+    largest = max((chunk.metadata.token_count for chunk in candidate), default=0)
+    print("Target:", budget, "Chunks:", len(candidate), "Largest:", largest)
 ```
 
-Measured on a 1,003-page reference PDF (pymupdf 1.28.2): parse ~36 min
-once, then `reassemble_chunks()` 0.7–1.2 s per budget — three orders of
-magnitude cheaper than re-parsing per configuration.
+Token budgets are targets. A preserved table or an indivisible text unit
+can exceed the target, and `metadata.token_count` sums the per-unit counts.
+Check the final input with your model's tokenizer when enforcing an input
+limit, including any context tags you add.
 
-Small-to-big retrieval is the same idea at query time: search precisely
-over small chunks, feed the LLM the surrounding big chunk. Both
-granularities come from the same parse and share element addresses, so
-the mapping is a set intersection, no extra bookkeeping:
+You can also search smaller chunks and use larger chunks for context.
+The two results share source element IDs. Find all larger chunks that
+share an element with the search result:
 
 ```python
-big = cd.reassemble_chunks(max_tokens=1200)     # 2 chunks: c0 pages 1-3, c1 pages 4-6
+larger = cd.reassemble_chunks(max_tokens=1200)
+hit = cd.get("c1")                    # an example result from the original index
+source_elements = set(hit.metadata.element_ids)
 
-# --- your code: replace with your retriever and LLM ---
-def search(query):
-    return "c1"                       # a small-chunk id from your index
+matches = [
+    chunk for chunk in larger
+    if source_elements.intersection(chunk.metadata.element_ids)
+]
+context = "\n\n".join(chunk.text for chunk in matches)
 
-def llm(query, context):
-    return f"answer grounded in {len(context)} characters"
-# --- end of your code ---
-
-query = "What is the capital of Belgium?"
-small = cd.get(search(query))                   # from cd, the 400-token index
-context = next(b for b in big
-               if set(small.metadata.element_ids) & set(b.metadata.element_ids))
-answer = llm(query, context.text)
-print(small.id, small.metadata.token_count, "->", context.id,
-      context.metadata.token_count, context.metadata.page_start, context.metadata.page_end)
-# -> c1 377 -> c0 1093 1 3
+print("Search result:", hit.id)
+print("Larger chunks:", [chunk.id for chunk in matches])
 ```
 
-### 6. Section-first chunking for keyword search and browsing
+Element IDs identify layout boxes, not individual sentences. A long box
+can span several chunks, so the first match may not contain the hit's
+text. Collecting all matches avoids that omission, but can produce a
+large context. Use neighboring chunks or the owning section when you
+need a different expansion rule. Chunk IDs themselves cannot be matched
+across sizes because each result starts numbering at `c0`.
 
-Keyword search without embeddings, and browsing a document by section,
-usually want section-shaped units around ~2000 tokens rather than
-embedding-sized ones. Large budgets keep section purity because a
-section-opening chunk never budget-merges backward
-(`respect_section_starts=True`, the default). `tests/test_370.pdf` is a
-five-page paper with 7 sections:
+### 6. Browse and search by section
+
+Use a larger token budget when you want longer passages. With
+`respect_section_starts=True`, the default, a section-opening chunk is
+not merged backward into the previous section during the budget merge.
 
 ```python
 cd_p = pymupdf4llm.to_chunks("tests/test_370.pdf")
-big = cd_p.reassemble_chunks(max_tokens=2000)
-by_section = {}
-for c in big:
-    by_section.setdefault(c.metadata.section_id, []).append(c.id)
-print(len(big), by_section)
-# -> 8 {'s0': ['c0'], 's1': ['c1', 'c2'], 's2': ['c3'], 's3': ['c4'],
-#       's4': ['c5'], 's5': ['c6'], 's6': ['c7']}
-#    every chunk sits inside exactly one section
+longer = cd_p.reassemble_chunks(max_tokens=2000)
 
-glued = cd_p.reassemble_chunks(max_tokens=2000, respect_section_starts=False)
-print(len(glued), [c.metadata.section_id for c in glued])
-# -> 3 ['s1', 's1', 's6']      sections packed together
+chunks_by_section = {}
+for chunk in longer:
+    chunks_by_section.setdefault(chunk.metadata.section_id, []).append(chunk.id)
+
+print(chunks_by_section)
 ```
 
-Index each entry under `" > ".join(chunk.metadata.section_path)` so a hit
-can be shown and navigated by section.
-
-The sections view itself is often the better keyword-search unit. A
-chunk hit can be a heading-only chunk (a heading followed directly by a
-subheading carries no body text), but a section is never under-evidenced:
-`SectionChunk.text` assembles the section's whole subtree, its heading
-plus every child section's content, and `token_count` is the subtree
-rollup, so oversized branches are easy to filter before indexing:
+For a section browser or a keyword index, `cd.sections` also provides
+complete section text and title paths:
 
 ```python
-# --- your code: replace with your keyword index ---
-keyword_index = {}
-# --- end of your code ---
+section_records = {
+    section.id: {
+        "title": section.title,
+        "path": " > ".join(section.path),
+        "text": section.text,
+        "pages": [section.page_start, section.page_end],
+    }
+    for section in cd_p.sections
+}
 
-for s in cd_p.sections:
-    if s.token_count <= 4000:              # whole subtree fits the budget
-        keyword_index[s.id] = {"text": s.text, "path": " > ".join(s.path)}
-print(sorted(keyword_index))
-# -> ['s2', 's3', 's4', 's5', 's6']      (s0 and s1 span the whole paper: 4711 / 4688 tokens)
+print(section_records.keys())
+```
 
-# Or expand a chunk hit to its owning section at query time:
+Section text includes its nested sections. Indexing both a parent and its
+children therefore repeats some content; choose the section levels your
+application needs. If a section is too long, use its chunks instead of
+dropping its content from the index.
+
+To expand a search result to its owning section:
+
+```python
 hit = cd_p.get("c11")
-print(repr(hit.text), hit.metadata.token_count, hit.metadata.section_id)
-# -> '### **AUTHOR INFORMATION**' 6 s2           (a heading-only chunk)
-section = cd_p.get(hit.metadata.section_id)
-print(section.token_count, section.child_chunk_ids, section.text[:87])
-# -> 43 ['c11', 'c12', 'c13'] ### **AUTHOR INFORMATION**
-#
-#    #### **Corresponding Author**
-#
-#    *saimasa@mat.shimane-u.ac.jp
+section_id = hit.metadata.section_id
+section = cd_p.get(section_id) if section_id is not None else None
+context = section.text if section is not None else hit.text
+
+print(context[:200])
 ```
 
-### 7. Framework export
+Chunks before the first detected heading, or in documents without detected
+headings, have no owning section. Check the final section text against your
+model's input limit before using it as context.
+
+### 7. Export to LangChain or LlamaIndex
+
+Install the package for the framework you use, then call its export
+method. Pass `doc_id` when the exported objects will share an index with
+other documents; exported IDs then become `"{doc_id}:{chunk.id}"`, which
+keeps them unique across documents. Without it, IDs are the local chunk
+IDs, and two documents both start at `c0`.
 
 ```python
-docs = cd.to_langchain_documents()   # needs langchain-core
-nodes = cd.to_llama_nodes()          # needs llama-index-core
-# -> 6 Documents / 6 TextNodes; docs[0].page_content == cd[0].text,
-#    metadata: the ChunkMetadata fields (page_start, page_end, bboxes, types, ...)
+# Requires langchain-core.
+documents = cd.to_langchain_documents(doc_id="national-capitals")
 ```
+
+```python
+# Requires llama-index-core.
+nodes = cd.to_llama_nodes(doc_id="national-capitals")
+```
+
+Both methods export `chunk.text` and the fields in `ChunkMetadata`.
+They do not use `tagged_content` as the document text. The original
+local chunk ID is always available as `metadata["chunk_id"]`, so a
+search result maps back to this document through `cd.get()`.
 
 ## tagged_content Format
 
@@ -719,11 +686,13 @@ nodes = cd.to_llama_nodes()          # needs llama-index-core
 ## Token counting
 
 Chunk budgets sum precomputed per-unit token counts (no re-tokenizing of
-joined text). The sum may differ from tokenizing the final chunk text by
-at most the number of unit joins — budgets are targets, not guarantees.
-Pass `tokenizer="cl100k_base"` (tiktoken) or a callable for exact counts
-per unit; the default is a 4-chars-per-token estimate. An unknown tiktoken
-encoding name raises `ValueError` rather than silently falling back.
+joined text), so `metadata.token_count` can differ slightly from
+tokenizing the final chunk text — budgets are targets, not guarantees.
+Pass `tokenizer="cl100k_base"` (tiktoken) or a callable to count with
+your own tokenizer; the default is a 4-chars-per-token estimate. An
+unknown tiktoken encoding name raises `ValueError` rather than silently
+falling back. When enforcing a hard model input limit, tokenize the
+exact final input you send, including any tags or prefixes you add.
 
 The resulting total is exposed as `metadata.token_count`, and on the
 `TableChunk` / `SectionChunk` views as `token_count`.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -354,14 +354,3 @@ def to_chunks(*args, **kwargs):
     else:
         return pymupdf4llm.helpers.pymupdf_rag.to_chunks(*args, **kwargs)
 
-
-def to_chunk(*args, **kwargs):
-    """Deprecated alias of :func:`to_chunks`."""
-    import warnings
-
-    warnings.warn(
-        "to_chunk is deprecated; use to_chunks",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return to_chunks(*args, **kwargs)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -293,3 +293,75 @@ def LlamaMarkdownReader(*args, **kwargs):
     from .llama import pdf_markdown_reader
 
     return pdf_markdown_reader.PDFMarkdownReader(*args, **kwargs)
+
+
+# Engine-internal parse flags; not part of the chunking surface. The HTML
+# table opt-in is exposed as table_output="html" like to_markdown, which
+# translates to the internal render_html_tables parse flag below.
+_CHUNK_INTERNAL_PARSE_FLAGS = {"render_html_tables"}
+
+
+def _layout_to_chunks(
+        doc,
+        **kwargs,
+    ):
+    import inspect
+
+    parse_fn = pymupdf4llm.helpers.document_layout.parse_document
+    # Split kwargs into parse_document args and to_chunks args, following
+    # the current parse_document signature (it has no **kwargs).
+    parse_keys = set(inspect.signature(parse_fn).parameters) - {"doc"}
+    parse_keys -= _CHUNK_INTERNAL_PARSE_FLAGS
+
+    internal = _CHUNK_INTERNAL_PARSE_FLAGS & set(kwargs)
+    if internal:
+        raise TypeError(
+            f"internal parse flags not accepted by to_chunks: {sorted(internal)}"
+        )
+
+    # table_output selects the table content representation, mirroring
+    # to_markdown: "html" routes to the parse-level HTML table engine.
+    table_output = kwargs.pop("table_output", "markdown")
+    if table_output not in ("markdown", "html"):
+        raise ValueError("table_output must be 'markdown' or 'html'")
+
+    # Map external names to parse_document names
+    aliases = {"dpi": "image_dpi"}
+    parse_kwargs = {}
+    chunk_kwargs = {}
+    for k, v in kwargs.items():
+        k = aliases.get(k, k)
+        if k in parse_keys:
+            parse_kwargs[k] = v
+        else:
+            chunk_kwargs[k] = v
+
+    if table_output == "html":
+        parse_kwargs["render_html_tables"] = True
+
+    # extract_images is parse-through sugar: it maps to parse_document's
+    # embed_images and is not a chunking parameter.
+    if chunk_kwargs.pop("extract_images", False) and "embed_images" not in parse_kwargs:
+        parse_kwargs["embed_images"] = True
+
+    parsed_doc = parse_fn(doc, **parse_kwargs)
+    return parsed_doc.to_chunks(**chunk_kwargs)
+
+
+def to_chunks(*args, **kwargs):
+    if _use_layout:
+        return _layout_to_chunks(*args, **kwargs)
+    else:
+        return pymupdf4llm.helpers.pymupdf_rag.to_chunks(*args, **kwargs)
+
+
+def to_chunk(*args, **kwargs):
+    """Deprecated alias of :func:`to_chunks`."""
+    import warnings
+
+    warnings.warn(
+        "to_chunk is deprecated; use to_chunks",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_chunks(*args, **kwargs)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -307,6 +307,8 @@ def _layout_to_chunks(
     ):
     import inspect
 
+    from .helpers.chunking import _validate_params
+
     parse_fn = pymupdf4llm.helpers.document_layout.parse_document
     # Split kwargs into parse_document args and to_chunks args, following
     # the current parse_document signature (it has no **kwargs).
@@ -322,8 +324,7 @@ def _layout_to_chunks(
     # table_output selects the table content representation, mirroring
     # to_markdown: "html" routes to the parse-level HTML table engine.
     table_output = kwargs.pop("table_output", "markdown")
-    if table_output not in ("markdown", "html"):
-        raise ValueError("table_output must be 'markdown' or 'html'")
+    _validate_params({"table_output": table_output})
 
     # Map external names to parse_document names
     aliases = {"dpi": "image_dpi"}
@@ -335,6 +336,11 @@ def _layout_to_chunks(
             parse_kwargs[k] = v
         else:
             chunk_kwargs[k] = v
+
+    # Chunking values are checked before the parse, so a bad budget or a
+    # misspelled mode fails immediately instead of after a full document
+    # parse.
+    _validate_params(chunk_kwargs)
 
     if table_output == "html":
         parse_kwargs["render_html_tables"] = True

--- a/src/helpers/chunking/README.md
+++ b/src/helpers/chunking/README.md
@@ -81,8 +81,11 @@ to the parse options: html mode re-splits text boxes around tables, so
 `to_markdown` and the side-effect-free guarantee.
 `tests/test_chunking_api.py` — public surface, kwargs router, containment,
 partial-parse addressing.
-`tests/test_chunking_v2.py` — id contracts, view round-trips, reassemble_chunks
-tiers, diagnostics, content_hash, canned html-mode adapter tests.
+`tests/test_chunking_document.py` — id contracts, view round-trips,
+reassemble_chunks tiers, diagnostics, content_hash, canned html-mode
+adapter tests.
+`tests/test_chunking_docs.py` — executes every Python block in
+`CHUNKING.md` in order, so the documented examples cannot silently break.
 `tests/test_chunking_html_tables.py` — live html-mode integration
 (D13 `<th>` header extraction, markdown|html exclusivity, chunk-text
 containment in `to_markdown(table_output="html")`); skipped unless the

--- a/src/helpers/chunking/README.md
+++ b/src/helpers/chunking/README.md
@@ -1,0 +1,89 @@
+# Layout-Aware Chunking — internals
+
+A retrieval-friendly chunker that splits a PDF into coherent pieces using
+**PDF-native layout signals** — layout boxes, box classes, font sizes,
+vertical and horizontal gaps, and page breaks — instead of slicing rendered
+Markdown. It runs without semantic embeddings and with no required
+dependency beyond PyMuPDF itself (`tiktoken` is optional).
+
+User-facing API documentation lives in the repository root `CHUNKING.md`.
+This file maps the pipeline for contributors.
+
+## Pipeline
+
+```
+parse_document(...)                       (document_layout.py — upstream)
+   Step A  LayoutBox → SentenceUnit           (sentence_builder.py)
+           text via text_source.box_to_markdown — the ONLY renderer callsite
+   Step B  boundary scores (layout-only)      (boundary_scorer.py)
+   Step C  assemble by score/structure/budget (chunk_assembler.py)
+   Step D  refine: split / semantic / budget  (chunk_assembler.py)
+   Step E  Chunk + t/f/s views + metadata     (serializer.py)
+        →  ChunkedDocument                    (chunked_document.py)
+```
+
+## Module contracts
+
+- **text_source.py** — single dispatch from a LayoutBox to its canonical
+  markdown, mirroring `ParsedDocument.to_markdown`. Upstream renderer
+  signature drift is absorbed here and nowhere else. `table_content()` is
+  the only reader of the `box.table` dict schema: it routes markdown|html
+  with `is not None` (a degenerate table carries `markdown == ""` and must
+  never route as html). Renderers that mutate textlines in place are fed a
+  defensive copy, so chunking never changes a later `to_markdown`.
+  Documented deviations: figures get `[Figure f{n}: WxH]` placeholders;
+  formula text is kept (to_markdown drops it); images stay in metadata.
+
+- **sentence_builder.py** — units carry precomputed structure hints,
+  geometry, and (for figures) the document-wide figure number that becomes
+  the `f{n}` view id.
+
+- **boundary_scorer.py** — layout signals only. No embedder, no network,
+  no model.
+
+- **chunk_assembler.py** — never joins or tokenizes chunk text; budgets
+  sum per-unit token counts precomputed by the pipeline (documented error
+  contract: sum vs joined-text tokenization differs by at most the number
+  of joins). ProtoChunks track a contiguous `unit_range` over the
+  renumbered working unit list.
+
+- **serializer.py** — materializes chunk text once, attaches citation
+  metadata (`section_path` = the innermost owning section's path, derived
+  from layout-detected headings — the PDF TOC is never consulted, so the
+  path stays populated and consistent with the sections view on documents
+  without bookmarks; D18), and builds the tables/figures/sections views
+  with bidirectional chunk links.
+  `TableChunk.headers` comes exclusively from `<th>` in the engine's HTML
+  rendering (stdlib HTMLParser) — provably `[]` on markdown-mode parses,
+  no local header heuristics.
+
+- **chunked_document.py** — the `Sequence[Chunk]` return type: element
+  registry (every box preserved, header/footer included), `get()` over all
+  public ids, `diagnostics`, assembly-tier `reassemble_chunks()` from retained units,
+  JSON-safe exports with `content_hash`.
+
+## Seam rules (rebase safety vs upstream)
+
+All chunking code lives in this package. `document_layout.py` is touched
+only inside the `ParsedDocument.to_chunks` method hunk; renderers, table
+code, and `to_markdown` are never edited. The engine-internal parse flag
+`render_html_tables` is rejected at the public boundary; the HTML table
+opt-in is exposed as `table_output="html"` (like `to_markdown`), and the
+public `edge_threshold` parse option passes through to `parse_document`.
+On a PyMuPDF without the layout-union table model, `table_output="html"`
+degrades to markdown tables with a parser warning. Element ids are scoped
+to the parse options: html mode re-splits text boxes around tables, so
+`p{page}.b{box}` addresses are not comparable across md/html parses.
+
+## Testing
+
+`tests/test_chunking_text_source.py` — per-box equivalence with
+`to_markdown` and the side-effect-free guarantee.
+`tests/test_chunking_api.py` — public surface, kwargs router, containment,
+partial-parse addressing.
+`tests/test_chunking_v2.py` — id contracts, view round-trips, reassemble_chunks
+tiers, diagnostics, content_hash, canned html-mode adapter tests.
+`tests/test_chunking_html_tables.py` — live html-mode integration
+(D13 `<th>` header extraction, markdown|html exclusivity, chunk-text
+containment in `to_markdown(table_output="html")`); skipped unless the
+installed PyMuPDF carries the layout-union table model.

--- a/src/helpers/chunking/__init__.py
+++ b/src/helpers/chunking/__init__.py
@@ -1,0 +1,177 @@
+"""Layout-Aware Chunking for PyMuPDF4LLM.
+
+Layout-only chunker using PDF-native signals (box boundaries, font
+changes, vertical gaps, page breaks).  Entry point: :func:`to_chunks`,
+returning a :class:`ChunkedDocument`.
+"""
+
+from .models import (
+    Chunk,
+    ChunkMetadata,
+    Element,
+    FigureChunk,
+    FinalChunk,
+    ProtoChunk,
+    SectionChunk,
+    SectionNode,
+    SentenceUnit,
+    TableChunk,
+    Unit,
+    element_id,
+)
+from .chunked_document import ChunkedDocument, REASSEMBLY_PARAMS
+from .sentence_builder import SentenceBuilder
+from .boundary_scorer import BoundaryScorer
+from .chunk_assembler import ChunkAssembler
+from .serializer import ChunkSerializer
+from .token_utils import TokenCounter
+
+# Default weights (layout signals only)
+WEIGHTS_LAYOUT = {
+    "w_box": 0.35,
+    "w_class": 0.50,
+    "w_page": 0.15,
+    "w_gap": 0.30,
+    "w_hgap": 0.30,
+    "w_font": 0.25,
+    "w_head": 0.45,
+    "w_foot": 0.20,
+    "w_list": 0.40,
+    "w_table": 0.60,
+    "w_caption": 0.80,
+}
+
+DEFAULTS = {
+    # assembly tier (accepted by reassemble_chunks)
+    "max_tokens": 400,
+    "min_tokens": 120,
+    "breakpoint_threshold": 0.5,
+    "merge_small_chunks": True,
+    "table_mode": "preserve",
+    "respect_section_starts": True,
+    # substrate tier (fixed per to_chunks call)
+    "header_footer_mode": "exclude",
+    "sentence_splitter": "default",
+    "tokenizer": None,
+    "weights": None,
+}
+
+
+def to_chunk(parsed_doc, **kwargs):
+    """Deprecated alias of :func:`to_chunks`."""
+    import warnings
+    warnings.warn(
+        "to_chunk is deprecated; use to_chunks",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_chunks(parsed_doc, **kwargs)
+
+
+def to_chunks(parsed_doc, **kwargs):
+    """Chunk a ParsedDocument; returns a :class:`ChunkedDocument`."""
+    unknown = set(kwargs) - set(DEFAULTS)
+    if unknown:
+        raise TypeError(f"unknown to_chunks parameters: {sorted(unknown)}")
+    params = {**DEFAULTS, **kwargs}
+
+    # Step A: Box → SentenceUnit (all units, header/footer included — the
+    # element registry must keep everything the parser saw)
+    builder = SentenceBuilder(splitter=params["sentence_splitter"])
+    all_units = builder.build_from_document(parsed_doc)
+
+    return _chunk_units(parsed_doc, all_units, params)
+
+
+def _chunk_units(parsed_doc, all_units, params):
+    """Steps B–E from prebuilt units (shared by to_chunks and reassemble_chunks)."""
+    elements = _build_elements(parsed_doc, all_units)
+
+    # Header/footer handling
+    hf_mode = params["header_footer_mode"]
+    if hf_mode == "auto":
+        builder = SentenceBuilder(splitter=params["sentence_splitter"])
+        repeated = builder.detect_repeated_headers_footers(parsed_doc)
+
+        def _is_repeated(s):
+            if (s.page_no, s.box_index) in repeated:
+                return True
+            return any((s.page_no, bi) in repeated
+                       for bi in s._source_box_indices)
+
+        units = [s for s in all_units if not _is_repeated(s)]
+    elif hf_mode == "exclude":
+        units = [s for s in all_units if not s.is_header_footer]
+    else:  # "include"
+        units = list(all_units)
+    hf_excluded = len(all_units) - len(units)
+
+    # Renumber so unit_range is contiguous over the working list, and
+    # precompute token counts once (assembly only sums; D12)
+    counter = TokenCounter(params["tokenizer"])
+    for i, u in enumerate(units):
+        u.sent_id = i
+        u.token_count = counter.count(u.text)
+
+    chunks, tables, figures, sections = [], [], [], []
+    if units:
+        # Step B: Boundary scoring (layout-only)
+        scorer = BoundaryScorer(weights=params["weights"] or WEIGHTS_LAYOUT)
+        scores = scorer.score_all(units)
+
+        # Steps C+D: Chunk assembly + refinement
+        assembler = ChunkAssembler(
+            max_tokens=params["max_tokens"],
+            min_tokens=params["min_tokens"],
+            threshold=params["breakpoint_threshold"],
+            table_mode=params["table_mode"],
+            merge_small_chunks=params["merge_small_chunks"],
+            respect_section_starts=params["respect_section_starts"],
+        )
+        proto_chunks = assembler.assemble(units, scores)
+        proto_chunks = assembler.refine(proto_chunks)
+
+        # Step E: Serialization + views
+        serializer = ChunkSerializer(doc=parsed_doc)
+        chunks, tables, figures, sections = serializer.serialize(proto_chunks)
+
+    return ChunkedDocument(
+        chunks,
+        elements=elements,
+        tables=tables,
+        figures=figures,
+        sections=sections,
+        params=params,
+        doc=parsed_doc,
+        all_units=all_units,
+        header_footer_excluded=hf_excluded,
+    )
+
+
+def _build_elements(parsed_doc, all_units):
+    """Element registry: one entry per layout box, everything preserved (D8).
+
+    Text comes from the units already rendered for the box; boxes that
+    produced no unit (nothing renders) appear with text "".  When repeated
+    header/footer units were merged, the merged text lives on the first
+    source box's element.
+    """
+    texts_by_box = {}
+    for u in all_units:
+        texts_by_box.setdefault((u.page_no, u.box_index), []).append(u.text)
+
+    elements = []
+    for page in parsed_doc.pages:
+        for box_idx, box in enumerate(page.boxes):
+            key = (page.page_number, box_idx)
+            texts = texts_by_box.get(key, [])
+            elements.append(Element(
+                id=element_id(*key),
+                page=key[0],
+                box=box_idx,
+                boxclass=box.boxclass,
+                bbox=(box.x0, box.y0, box.x1, box.y1),
+                text="\n".join(texts),
+                is_header_footer=box.boxclass in ("page-header", "page-footer"),
+            ))
+    return elements

--- a/src/helpers/chunking/__init__.py
+++ b/src/helpers/chunking/__init__.py
@@ -10,13 +10,11 @@ from .models import (
     ChunkMetadata,
     Element,
     FigureChunk,
-    FinalChunk,
     ProtoChunk,
     SectionChunk,
     SectionNode,
     SentenceUnit,
     TableChunk,
-    Unit,
     element_id,
 )
 from .chunked_document import ChunkedDocument, REASSEMBLY_PARAMS
@@ -55,17 +53,6 @@ DEFAULTS = {
     "tokenizer": None,
     "weights": None,
 }
-
-
-def to_chunk(parsed_doc, **kwargs):
-    """Deprecated alias of :func:`to_chunks`."""
-    import warnings
-    warnings.warn(
-        "to_chunk is deprecated; use to_chunks",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return to_chunks(parsed_doc, **kwargs)
 
 
 def to_chunks(parsed_doc, **kwargs):

--- a/src/helpers/chunking/__init__.py
+++ b/src/helpers/chunking/__init__.py
@@ -55,12 +55,49 @@ DEFAULTS = {
 }
 
 
+# Accepted values for the enum-valued parameters. A typo ("exlcude") must
+# fail loudly instead of silently selecting the fallback behaviour.
+_ENUM_VALUES = {
+    "header_footer_mode": ("exclude", "auto", "include"),
+    "sentence_splitter": ("default", "multilingual"),
+    "table_mode": ("preserve", "isolate"),
+    "table_output": ("markdown", "html"),
+}
+
+
+def _validate_params(params):
+    """Reject invalid parameter values, naming the parameter.
+
+    Validates only the keys present in *params*, so it can screen partial
+    kwargs before parsing as well as a fully merged parameter set.
+    """
+    for name, allowed in _ENUM_VALUES.items():
+        if name in params and params[name] not in allowed:
+            raise ValueError(
+                f"{name} must be one of {list(allowed)}, got {params[name]!r}"
+            )
+
+    max_tokens = params.get("max_tokens")
+    if max_tokens is not None and (
+            not isinstance(max_tokens, int) or isinstance(max_tokens, bool)
+            or max_tokens <= 0):
+        raise ValueError(f"max_tokens must be a positive int, got {max_tokens!r}")
+
+    min_tokens = params.get("min_tokens")
+    if min_tokens is not None and (
+            not isinstance(min_tokens, int) or isinstance(min_tokens, bool)
+            or min_tokens < 0):
+        raise ValueError(
+            f"min_tokens must be a non-negative int, got {min_tokens!r}")
+
+
 def to_chunks(parsed_doc, **kwargs):
     """Chunk a ParsedDocument; returns a :class:`ChunkedDocument`."""
     unknown = set(kwargs) - set(DEFAULTS)
     if unknown:
         raise TypeError(f"unknown to_chunks parameters: {sorted(unknown)}")
     params = {**DEFAULTS, **kwargs}
+    _validate_params(params)
 
     # Step A: Box → SentenceUnit (all units, header/footer included — the
     # element registry must keep everything the parser saw)
@@ -72,6 +109,7 @@ def to_chunks(parsed_doc, **kwargs):
 
 def _chunk_units(parsed_doc, all_units, params):
     """Steps B–E from prebuilt units (shared by to_chunks and reassemble_chunks)."""
+    _validate_params(params)
     elements = _build_elements(parsed_doc, all_units)
 
     # Header/footer handling

--- a/src/helpers/chunking/boundary_scorer.py
+++ b/src/helpers/chunking/boundary_scorer.py
@@ -1,0 +1,105 @@
+"""Step B: Compute boundary scores between adjacent SentenceUnits."""
+
+import statistics
+
+from .models import SentenceUnit, horizontal_overlap_ratio, caption_matches_element
+
+
+class BoundaryScorer:
+    """Scores the likelihood of a chunk boundary between adjacent sentence pairs.
+
+    Layout-only: PDF-native signals (boxes, classes, gaps, fonts, structure
+    hints). Higher score = more likely to break here.
+    """
+
+    def __init__(self, weights: dict):
+        self.weights = weights
+        self._median_gap: float = 12.0
+        self._median_font: float = 10.0
+
+    def score_all(self, sents: list[SentenceUnit]) -> list[float]:
+        """Compute break scores for all adjacent pairs.
+
+        Returns list of len(sents)-1 scores.
+        """
+        if len(sents) < 2:
+            return []
+
+        gaps = [s.line_gap_before for s in sents if s.line_gap_before is not None and s.line_gap_before > 0]
+        self._median_gap = statistics.median(gaps) if gaps else 12.0
+
+        sizes = [s.font_size_dominant for s in sents if s.font_size_dominant > 0]
+        self._median_font = statistics.median(sizes) if sizes else 10.0
+
+        scores = []
+        for i in range(len(sents) - 1):
+            scores.append(self.score_pair(sents[i], sents[i + 1]))
+
+        return scores
+
+    def score_pair(self, left: SentenceUnit, right: SentenceUnit) -> float:
+        """Compute break score for a single adjacent pair."""
+        w = self.weights
+        score = 0.0
+
+        # Layout signals
+        box_changed = (left.box_index != right.box_index) or (left.page_no != right.page_no)
+        score += w.get("w_box", 0) * float(box_changed)
+
+        score += w.get("w_class", 0) * float(left.boxclass != right.boxclass)
+        score += w.get("w_page", 0) * float(left.page_no != right.page_no)
+        score += w.get("w_gap", 0) * self._compute_gap_jump(right)
+        score += w.get("w_font", 0) * self._compute_font_jump(left, right)
+
+        # Structure hint signals
+        score += w.get("w_head", 0) * float(right.is_heading_hint and not left.is_heading_hint)
+        score += w.get("w_foot", 0) * float(not left.is_footnote and right.is_footnote)
+        score += w.get("w_hgap", 0) * self._compute_hgap_jump(left, right)
+
+        # Suppression signals (negative = keep together)
+        score -= w.get("w_list", 0) * float(left.is_list_item and right.is_list_item and not box_changed)
+        score -= w.get("w_table", 0) * float(left.is_table_content and right.is_table_content)
+        score -= w.get("w_caption", 0) * float(self._is_caption_adjacent(left, right))
+
+        return score
+
+    def _compute_gap_jump(self, right: SentenceUnit) -> float:
+        """Normalized vertical gap signal (0.0-1.0)."""
+        gap = right.line_gap_before
+        if gap is None or self._median_gap <= 0:
+            return 0.0
+        ratio = gap / self._median_gap
+        if ratio <= 1.5:
+            return 0.0
+        return min(1.0, (ratio - 1.5) / 2.0)
+
+    def _compute_hgap_jump(self, left: SentenceUnit, right: SentenceUnit) -> float:
+        """Horizontal non-overlap signal for multi-column detection (0.0-1.0)."""
+        if left.page_no != right.page_no:
+            return 0.0
+
+        ratio = horizontal_overlap_ratio(left.bbox, right.bbox)
+        if ratio >= 0.5:
+            return 0.0
+        # 0.5 → 0.0, 0.0 → 1.0
+        return 1.0 - ratio * 2.0
+
+    def _is_caption_adjacent(self, left: SentenceUnit, right: SentenceUnit) -> bool:
+        """Check if a caption is adjacent to its target element."""
+        if left.page_no != right.page_no:
+            return False
+        return caption_matches_element(left, right) or caption_matches_element(right, left)
+
+    def _compute_font_jump(self, left: SentenceUnit, right: SentenceUnit) -> float:
+        """Font size change signal (0.0-1.0)."""
+        if left.font_size_dominant <= 0 or right.font_size_dominant <= 0:
+            return 0.0
+
+        diff = abs(left.font_size_dominant - right.font_size_dominant)
+        if diff < 0.5:
+            return 0.0
+
+        if self._median_font > 0:
+            ratio = diff / self._median_font
+            return min(1.0, ratio)
+        return min(1.0, diff / 10.0)

--- a/src/helpers/chunking/chunk_assembler.py
+++ b/src/helpers/chunking/chunk_assembler.py
@@ -385,7 +385,7 @@ class ChunkAssembler:
             box_indices=box_indices,
             bboxes=bboxes,
             chunk_type_hint=primary_type,
-            chunk_types=all_types,
+            types=all_types,
             _sentences=list(sents),
         )
 

--- a/src/helpers/chunking/chunk_assembler.py
+++ b/src/helpers/chunking/chunk_assembler.py
@@ -158,7 +158,7 @@ class ChunkAssembler:
         if not sents:
             return [chunk]
 
-        if chunk.chunk_type_hint == "table" and self.table_mode == "preserve":
+        if chunk.primary_type == "table" and self.table_mode == "preserve":
             return [chunk]
 
         result = []
@@ -243,7 +243,7 @@ class ChunkAssembler:
 
     def _is_semantic_pair(self, a: ProtoChunk, b: ProtoChunk) -> bool:
         """Check if (a, b) form a semantic pair that should stay together."""
-        if a.chunk_type_hint == "header_footer" or b.chunk_type_hint == "header_footer":
+        if a.primary_type == "header_footer" or b.primary_type == "header_footer":
             return False
         if a.token_count + b.token_count > self.max_tokens:
             return False
@@ -253,22 +253,22 @@ class ChunkAssembler:
             return False
 
         # heading + following content (any non-heading type)
-        if a.chunk_type_hint == "heading" and b.chunk_type_hint != "heading":
+        if a.primary_type == "heading" and b.primary_type != "heading":
             return True
 
         # consecutive list chunks → merge into one logical list
-        if a.chunk_type_hint == "list" and b.chunk_type_hint == "list":
+        if a.primary_type == "list" and b.primary_type == "list":
             return True
 
         # caption + element (caption first)
         a_is_caption = bool(a._sentences) and all(s.is_caption for s in a._sentences)
-        if a_is_caption and b.chunk_type_hint in _ELEMENT_TYPES:
-            return self._caption_target_matches(a, b.chunk_type_hint)
+        if a_is_caption and b.primary_type in _ELEMENT_TYPES:
+            return self._caption_target_matches(a, b.primary_type)
 
         # element + caption (element first)
         b_is_caption = bool(b._sentences) and all(s.is_caption for s in b._sentences)
-        if a.chunk_type_hint in _ELEMENT_TYPES and b_is_caption:
-            return self._caption_target_matches(b, a.chunk_type_hint)
+        if a.primary_type in _ELEMENT_TYPES and b_is_caption:
+            return self._caption_target_matches(b, a.primary_type)
 
         return False
 
@@ -320,13 +320,13 @@ class ChunkAssembler:
         NOT checked here — budget merge is purely about filling token
         capacity with sequentially adjacent chunks.
         """
-        if a.chunk_type_hint == "header_footer" or b.chunk_type_hint == "header_footer":
+        if a.primary_type == "header_footer" or b.primary_type == "header_footer":
             return False
-        if b.chunk_type_hint == "heading":
+        if b.primary_type == "heading":
             return False
         # A chunk opening with a heading is a section start; merging it
         # backward would attach a section's head to the previous section's
-        # tail. (chunk_type_hint is "heading" only for lone headings, so
+        # tail. (primary_type is "heading" only for lone headings, so
         # the check above does not cover heading+content chunks — D18.)
         if (self.respect_section_starts and b._sentences
                 and b._sentences[0].is_heading_hint):
@@ -334,7 +334,7 @@ class ChunkAssembler:
         # table_mode="isolate": table chunks stay separate in budget merge
         # (semantic merge heading+table / caption+table is still allowed)
         if self.table_mode == "isolate":
-            if a.chunk_type_hint == "table" or b.chunk_type_hint == "table":
+            if a.primary_type == "table" or b.primary_type == "table":
                 return False
         if a.token_count + b.token_count > self.max_tokens:
             return False
@@ -384,7 +384,7 @@ class ChunkAssembler:
             page_end=sents[-1].page_no,
             box_indices=box_indices,
             bboxes=bboxes,
-            chunk_type_hint=primary_type,
+            primary_type=primary_type,
             types=all_types,
             _sentences=list(sents),
         )

--- a/src/helpers/chunking/chunk_assembler.py
+++ b/src/helpers/chunking/chunk_assembler.py
@@ -1,0 +1,531 @@
+"""Steps C+D: Assemble initial chunks and refine via split/merge.
+
+Token budgeting works on per-unit token counts precomputed once by the
+pipeline and summed here (D12 error contract: the sum of unit counts may
+differ from tokenizing the joined text by up to the number of joins).
+Assembly never re-tokenizes or re-joins chunk text; ``ProtoChunk.text``
+stays empty until serialization.
+"""
+
+from .models import SentenceUnit, ProtoChunk, union_bbox, group_bboxes, horizontal_overlap_ratio, caption_matches_element
+
+_ELEMENT_TYPES = frozenset({"table", "figure", "list"})
+
+
+class ChunkAssembler:
+    """Assembles SentenceUnits into ProtoChunks based on boundary scores,
+    then refines by splitting oversized and merging undersized chunks.
+    """
+
+    def __init__(
+        self,
+        max_tokens: int = 400,
+        min_tokens: int = 120,
+        threshold: float = 0.5,
+        table_mode: str = "preserve",
+        merge_small_chunks: bool = True,
+        respect_section_starts: bool = True,
+    ):
+        self.max_tokens = max_tokens
+        self.min_tokens = min_tokens
+        self.threshold = threshold
+        self.table_mode = table_mode
+        self.merge_small = merge_small_chunks
+        self.respect_section_starts = respect_section_starts
+
+    # ── Step C: Initial assembly ─────────────────────────────────────
+
+    def assemble(self, sents: list[SentenceUnit], scores: list[float]) -> list[ProtoChunk]:
+        """Form initial chunks from sentences + boundary scores.
+
+        A new chunk starts when:
+        - break_score > threshold, OR
+        - structural break (heading, type transition), OR
+        - adding the next sentence would exceed max_tokens
+        """
+        if not sents:
+            return []
+
+        chunks = []
+        current_sents = [sents[0]]
+        current_tokens = sents[0].token_count
+
+        for i, score in enumerate(scores):
+            next_sent = sents[i + 1]
+
+            # Break conditions (lazy: skip expensive checks if earlier one triggers)
+            do_break = score > self.threshold
+            if not do_break:
+                do_break = self._is_structural_break(current_sents[-1], next_sent)
+            if not do_break:
+                do_break = current_tokens + next_sent.token_count > self.max_tokens
+
+            # Never split sentences from the same box — they share a bbox
+            if do_break and (next_sent.box_index == current_sents[-1].box_index
+                             and next_sent.page_no == current_sents[-1].page_no):
+                do_break = False
+
+            if do_break:
+                chunks.append(self._make_proto_chunk(len(chunks), current_sents))
+                current_sents = [next_sent]
+                current_tokens = next_sent.token_count
+            else:
+                current_sents.append(next_sent)
+                current_tokens += next_sent.token_count
+
+        # Flush remaining
+        if current_sents:
+            chunks.append(self._make_proto_chunk(len(chunks), current_sents))
+
+        return chunks
+
+    # ── Step D: Refine ───────────────────────────────────────────────
+
+    def refine(self, chunks: list[ProtoChunk]) -> list[ProtoChunk]:
+        """Refine chunks via split and multi-depth merge.
+
+        1. Split  — break oversized chunks at sentence boundaries
+        2. Semantic merge — heading+content, caption+element
+        3. Budget merge  — greedily combine within max_tokens
+        """
+        # Step 1: Split oversized chunks
+        split: list[ProtoChunk] = []
+        for chunk in chunks:
+            if chunk.token_count > self.max_tokens:
+                split.extend(self._split_chunk(chunk))
+            else:
+                split.append(chunk)
+
+        if not self.merge_small:
+            return self._renumber(split)
+
+        # Step 2: Semantic merge — preserve heading+content and caption+element pairs
+        semantic = self._merge_semantic(split)
+
+        # Step 3: Budget merge — greedily combine within max_tokens
+        merged = self._merge_budget(semantic)
+        return self._renumber(merged)
+
+    # ── Structural break (used by assemble) ──────────────────────────
+
+    def _is_structural_break(self, prev: SentenceUnit, next_sent: SentenceUnit) -> bool:
+        """Check if there's a forced structural break between units."""
+        # Caption-element pairs should NOT be structurally separated
+        if self._is_caption_element_pair(prev, next_sent):
+            return False
+        # Heading followed by table/figure on same page → keep together
+        if self._is_heading_element_pair(prev, next_sent):
+            return False
+        if next_sent.is_header_footer != prev.is_header_footer:
+            return True
+        if next_sent.is_table_content != prev.is_table_content:
+            return True
+        if next_sent.is_figure_related != prev.is_figure_related:
+            return True
+        if next_sent.is_heading_hint:
+            return True
+        return False
+
+    @staticmethod
+    def _is_heading_element_pair(prev: SentenceUnit, next_sent: SentenceUnit) -> bool:
+        """Check if prev is a heading and next is its associated element."""
+        if not prev.is_heading_hint:
+            return False
+        if prev.page_no != next_sent.page_no:
+            return False
+        if not (next_sent.is_table_content or next_sent.is_figure_related):
+            return False
+        return ChunkAssembler._has_horizontal_overlap(prev.bbox, next_sent.bbox)
+
+    @staticmethod
+    def _is_caption_element_pair(a: SentenceUnit, b: SentenceUnit) -> bool:
+        """Check if a and b form a caption-element pair on the same page."""
+        if a.page_no != b.page_no:
+            return False
+        if not ChunkAssembler._has_horizontal_overlap(a.bbox, b.bbox):
+            return False
+        return caption_matches_element(a, b) or caption_matches_element(b, a)
+
+    # ── Split ────────────────────────────────────────────────────────
+
+    def _split_chunk(self, chunk: ProtoChunk) -> list[ProtoChunk]:
+        """Split an oversized chunk at sentence boundaries.
+
+        Prefers splitting at box boundaries (where box_index changes)
+        to avoid the same box's bbox appearing in two chunks.
+        """
+        sents = chunk._sentences
+        if not sents:
+            return [chunk]
+
+        if chunk.chunk_type_hint == "table" and self.table_mode == "preserve":
+            return [chunk]
+
+        result = []
+        current = []
+        current_tokens = 0
+
+        for sent in sents:
+            if sent.token_count > self.max_tokens:
+                if current:
+                    result.append(self._make_proto_chunk(0, current))
+                    current = []
+                    current_tokens = 0
+                result.append(self._make_proto_chunk(0, [sent]))
+                continue
+
+            if current_tokens + sent.token_count > self.max_tokens and current:
+                # Prefer splitting at a box boundary: if the new sentence
+                # shares box_index with the last sentence in current, move
+                # those shared sentences to the next chunk.
+                split_point = len(current)
+                if current and sent.box_index == current[-1].box_index:
+                    # Find where this box_index started in current
+                    bi = sent.box_index
+                    pg = sent.page_no
+                    j = len(current) - 1
+                    while j > 0 and current[j].box_index == bi and current[j].page_no == pg:
+                        j -= 1
+                    if j > 0:  # don't empty the entire current
+                        split_point = j + 1
+
+                keep = current[:split_point]
+                carry = current[split_point:]
+                if keep:
+                    result.append(self._make_proto_chunk(0, keep))
+                current = carry + [sent]
+                current_tokens = sum(s.token_count for s in current)
+            else:
+                current.append(sent)
+                current_tokens += sent.token_count
+
+        if current:
+            result.append(self._make_proto_chunk(0, current))
+
+        return result
+
+    # ── Semantic merge ───────────────────────────────────────────────
+
+    def _merge_semantic(self, chunks: list[ProtoChunk]) -> list[ProtoChunk]:
+        """Merge semantic pairs in a single forward pass.
+
+        Pairs: heading + following content, caption + adjacent element.
+        Semantic pairs always produce a single union bbox (not a list).
+        """
+        if len(chunks) <= 1:
+            return chunks
+
+        result: list[ProtoChunk] = []
+        i = 0
+        while i < len(chunks):
+            chunk = chunks[i]
+
+            if i + 1 < len(chunks) and self._is_semantic_pair(chunk, chunks[i + 1]):
+                # Greedily consume all consecutive semantic partners
+                combined = list(chunk._sentences)
+                j = i + 1
+                while j < len(chunks) and self._is_semantic_pair(
+                    self._make_proto_chunk(0, combined), chunks[j]
+                ):
+                    combined.extend(chunks[j]._sentences)
+                    j += 1
+                pc = self._make_proto_chunk(0, combined)
+                # Semantic pairs are tightly related — union per page
+                if len(pc.bboxes) > 1:
+                    pc.bboxes = _union_per_page(pc.bboxes)
+                result.append(pc)
+                i = j
+            else:
+                result.append(chunk)
+                i += 1
+
+        return result
+
+    def _is_semantic_pair(self, a: ProtoChunk, b: ProtoChunk) -> bool:
+        """Check if (a, b) form a semantic pair that should stay together."""
+        if a.chunk_type_hint == "header_footer" or b.chunk_type_hint == "header_footer":
+            return False
+        if a.token_count + b.token_count > self.max_tokens:
+            return False
+        if abs(a.page_end - b.page_start) > 1:
+            return False
+        if not self._any_bbox_overlap(a.bboxes, b.bboxes):
+            return False
+
+        # heading + following content (any non-heading type)
+        if a.chunk_type_hint == "heading" and b.chunk_type_hint != "heading":
+            return True
+
+        # consecutive list chunks → merge into one logical list
+        if a.chunk_type_hint == "list" and b.chunk_type_hint == "list":
+            return True
+
+        # caption + element (caption first)
+        a_is_caption = bool(a._sentences) and all(s.is_caption for s in a._sentences)
+        if a_is_caption and b.chunk_type_hint in _ELEMENT_TYPES:
+            return self._caption_target_matches(a, b.chunk_type_hint)
+
+        # element + caption (element first)
+        b_is_caption = bool(b._sentences) and all(s.is_caption for s in b._sentences)
+        if a.chunk_type_hint in _ELEMENT_TYPES and b_is_caption:
+            return self._caption_target_matches(b, a.chunk_type_hint)
+
+        return False
+
+    @staticmethod
+    def _caption_target_matches(caption_chunk: ProtoChunk, element_type: str) -> bool:
+        """Check if caption's target type matches the element type."""
+        target_types = {
+            s.caption_target_type for s in caption_chunk._sentences
+            if s.caption_target_type
+        }
+        if not target_types:
+            return True  # no specific target → match any element
+        return element_type in target_types
+
+    # ── Budget merge ─────────────────────────────────────────────────
+
+    def _merge_budget(self, chunks: list[ProtoChunk]) -> list[ProtoChunk]:
+        """Greedily merge adjacent chunks that fit within max_tokens.
+
+        Preserves bbox structure from earlier phases: instead of rebuilding
+        bboxes from scratch, concatenates the bbox lists of both chunks.
+        This keeps semantic-merge union bboxes intact.
+        """
+        if len(chunks) <= 1:
+            return chunks
+
+        merged = [chunks[0]]
+        for i in range(1, len(chunks)):
+            prev = merged[-1]
+            curr = chunks[i]
+
+            if self._can_budget_merge(prev, curr):
+                combined_sents = prev._sentences + curr._sentences
+                pc = self._make_proto_chunk(0, combined_sents)
+                # Re-group at chunk-level bboxes (not sentence-level) so that
+                # semantic-merge unions are preserved as atomic inputs while
+                # compatible bboxes (matching x0+x1 or y0+y1 pair) still merge.
+                pc.bboxes = _regroup_page_bboxes(prev.bboxes + curr.bboxes)
+                merged[-1] = pc
+            else:
+                merged.append(curr)
+
+        return merged
+
+    def _can_budget_merge(self, a: ProtoChunk, b: ProtoChunk) -> bool:
+        """Check if two adjacent chunks can be merged within budget.
+
+        Spatial proximity (bbox overlap, page distance) is intentionally
+        NOT checked here — budget merge is purely about filling token
+        capacity with sequentially adjacent chunks.
+        """
+        if a.chunk_type_hint == "header_footer" or b.chunk_type_hint == "header_footer":
+            return False
+        if b.chunk_type_hint == "heading":
+            return False
+        # A chunk opening with a heading is a section start; merging it
+        # backward would attach a section's head to the previous section's
+        # tail. (chunk_type_hint is "heading" only for lone headings, so
+        # the check above does not cover heading+content chunks — D18.)
+        if (self.respect_section_starts and b._sentences
+                and b._sentences[0].is_heading_hint):
+            return False
+        # table_mode="isolate": table chunks stay separate in budget merge
+        # (semantic merge heading+table / caption+table is still allowed)
+        if self.table_mode == "isolate":
+            if a.chunk_type_hint == "table" or b.chunk_type_hint == "table":
+                return False
+        if a.token_count + b.token_count > self.max_tokens:
+            return False
+        return True
+
+    # ── Helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _has_horizontal_overlap(bbox_a: tuple, bbox_b: tuple, min_ratio: float = 0.3) -> bool:
+        """Check if two single bboxes have sufficient horizontal overlap."""
+        return horizontal_overlap_ratio(bbox_a, bbox_b) >= min_ratio
+
+    @staticmethod
+    def _any_bbox_overlap(bboxes_a: list, bboxes_b: list, min_ratio: float = 0.3) -> bool:
+        """Check if any bbox from list a overlaps horizontally with any from list b.
+
+        Handles both 4-tuple (x0,y0,x1,y1) and 5-tuple (page,x0,y0,x1,y1).
+        """
+        for ba in bboxes_a:
+            ba4 = ba[1:] if len(ba) == 5 else ba
+            for bb in bboxes_b:
+                bb4 = bb[1:] if len(bb) == 5 else bb
+                if horizontal_overlap_ratio(ba4, bb4) >= min_ratio:
+                    return True
+        return False
+
+    def _make_proto_chunk(self, chunk_id: int, sents: list[SentenceUnit]) -> ProtoChunk:
+        """Create a ProtoChunk from a contiguous run of SentenceUnits.
+
+        Text is NOT materialized here (serialization does that once);
+        token_count is the sum of precomputed unit counts (D12).
+        """
+        primary_type, all_types = self._infer_chunk_types(sents)
+
+        bboxes = _group_bboxes_by_page(sents)
+
+        box_indices = list(dict.fromkeys(
+            (s.page_no, s.box_index) for s in sents
+        ))
+
+        return ProtoChunk(
+            chunk_id=chunk_id,
+            sent_ids=[s.sent_id for s in sents],
+            token_count=sum(s.token_count for s in sents),
+            unit_range=(sents[0].sent_id, sents[-1].sent_id + 1),
+            page_start=sents[0].page_no,
+            page_end=sents[-1].page_no,
+            box_indices=box_indices,
+            bboxes=bboxes,
+            chunk_type_hint=primary_type,
+            chunk_types=all_types,
+            _sentences=list(sents),
+        )
+
+    @staticmethod
+    def _infer_chunk_types(sents: list[SentenceUnit]) -> tuple[str, list[str]]:
+        """Collect all content types and determine the primary type.
+
+        Returns (primary_type, all_types) where all_types preserves
+        reading order and primary_type is the dominant element type.
+        """
+        # Collect types in reading order (deduplicated, stable)
+        seen = set()
+        all_types = []
+        for s in sents:
+            t = None
+            if s.is_header_footer:
+                t = "header_footer"
+            elif s.is_table_content:
+                t = "table"
+            elif s.is_figure_related:
+                t = "figure"
+            elif s.is_list_item:
+                t = "list"
+            elif s.is_heading_hint:
+                t = "heading"
+            elif s.is_caption:
+                t = "caption"
+            elif s.is_footnote:
+                t = "footnote"
+            else:
+                t = "paragraph"
+            if t not in seen:
+                seen.add(t)
+                all_types.append(t)
+
+        # Primary type: first element type wins, then heading, then paragraph
+        _ELEMENT_PRIORITY = ("table", "figure", "list")
+        for et in _ELEMENT_PRIORITY:
+            if et in seen:
+                return et, all_types
+        if "header_footer" in seen:
+            return "header_footer", all_types
+        if "heading" in seen and len(sents) == 1:
+            return "heading", all_types
+        if "footnote" in seen:
+            return "footnote", all_types
+        return "paragraph", all_types
+
+    @staticmethod
+    def _renumber(chunks: list[ProtoChunk]) -> list[ProtoChunk]:
+        """Renumber chunk IDs sequentially."""
+        for i, chunk in enumerate(chunks):
+            chunk.chunk_id = i
+        return chunks
+
+
+def _group_bboxes_by_page(sents) -> list[tuple]:
+    """Group sentence bboxes by page, then by edge-pair within each page.
+
+    Consecutive list-items are pre-merged into a single union bbox before
+    edge-pair grouping, since individual list-item x1 varies by text length
+    while they share the same x0 (indentation level).
+
+    Returns list of (page, x0, y0, x1, y1) 5-tuples.
+    """
+    from collections import defaultdict
+
+    # Pre-merge consecutive list-items into union bboxes
+    merged_entries = []  # (page_no, bbox)
+    list_run = []
+    for s in sents:
+        if s.is_list_item:
+            list_run.append(s)
+        else:
+            if list_run:
+                merged_entries.extend(_flush_list_run(list_run))
+                list_run = []
+            merged_entries.append((s.page_no, s.bbox))
+    if list_run:
+        merged_entries.extend(_flush_list_run(list_run))
+
+    # Group by page, then edge-pair
+    page_bboxes = defaultdict(list)
+    for page_no, bbox in merged_entries:
+        page_bboxes[page_no].append(bbox)
+
+    result = []
+    for page_no in sorted(page_bboxes.keys()):
+        grouped = group_bboxes(iter(page_bboxes[page_no]))
+        for bbox in grouped:
+            result.append((page_no, *bbox))
+    return result
+
+
+def _flush_list_run(items) -> list[tuple]:
+    """Union consecutive list-item sentences into one bbox per page."""
+    from collections import defaultdict
+    by_page = defaultdict(list)
+    for s in items:
+        by_page[s.page_no].append(s.bbox)
+    result = []
+    for page_no in sorted(by_page.keys()):
+        bboxes = by_page[page_no]
+        x0 = min(b[0] for b in bboxes)
+        y0 = min(b[1] for b in bboxes)
+        x1 = max(b[2] for b in bboxes)
+        y1 = max(b[3] for b in bboxes)
+        result.append((page_no, (x0, y0, x1, y1)))
+    return result
+
+
+def _union_per_page(page_bboxes: list[tuple]) -> list[tuple]:
+    """Union all bboxes on each page into a single bbox per page."""
+    from collections import defaultdict
+    by_page = defaultdict(list)
+    for pb in page_bboxes:
+        page, x0, y0, x1, y1 = pb
+        by_page[page].append((x0, y0, x1, y1))
+
+    result = []
+    for page_no in sorted(by_page.keys()):
+        u = union_bbox(iter(by_page[page_no]))
+        result.append((page_no, *u))
+    return result
+
+
+def _regroup_page_bboxes(page_bboxes: list[tuple]) -> list[tuple]:
+    """Re-group 5-tuple bboxes (page, x0, y0, x1, y1) by page.
+
+    Preserves page info while merging compatible bboxes within each page.
+    """
+    from collections import defaultdict
+    by_page = defaultdict(list)
+    for pb in page_bboxes:
+        page, x0, y0, x1, y1 = pb
+        by_page[page].append((x0, y0, x1, y1))
+
+    result = []
+    for page_no in sorted(by_page.keys()):
+        grouped = group_bboxes(iter(by_page[page_no]))
+        for bbox in grouped:
+            result.append((page_no, *bbox))
+    return result

--- a/src/helpers/chunking/chunk_assembler.py
+++ b/src/helpers/chunking/chunk_assembler.py
@@ -86,7 +86,8 @@ class ChunkAssembler:
 
         1. Split  — break oversized chunks at sentence boundaries
         2. Semantic merge — heading+content, caption+element
-        3. Budget merge  — greedily combine within max_tokens
+        3. Budget merge  — combine undersized neighbours within max_tokens
+           (a pair is merged only while one side is below min_tokens)
         """
         # Step 1: Split oversized chunks
         split: list[ProtoChunk] = []
@@ -151,8 +152,15 @@ class ChunkAssembler:
     def _split_chunk(self, chunk: ProtoChunk) -> list[ProtoChunk]:
         """Split an oversized chunk at sentence boundaries.
 
-        Prefers splitting at box boundaries (where box_index changes)
-        to avoid the same box's bbox appearing in two chunks.
+        Prefers splitting at box boundaries (where box_index changes) to
+        avoid the same box's bbox appearing in two chunks — but only when
+        carrying the whole shared-box run forward still fits the budget.
+        Otherwise the box is split at a sentence boundary instead: a
+        cosmetic bbox split is cheaper than a chunk over max_tokens.
+
+        With every unit within the budget, every chunk this returns is
+        within the budget too.  Units larger than max_tokens (and, in
+        table_mode="preserve", tables) are the documented exceptions.
         """
         sents = chunk._sentences
         if not sents:
@@ -177,9 +185,11 @@ class ChunkAssembler:
             if current_tokens + sent.token_count > self.max_tokens and current:
                 # Prefer splitting at a box boundary: if the new sentence
                 # shares box_index with the last sentence in current, move
-                # those shared sentences to the next chunk.
+                # those shared sentences to the next chunk — but only if
+                # the moved run plus this sentence still fits the budget.
                 split_point = len(current)
-                if current and sent.box_index == current[-1].box_index:
+                if (sent.box_index == current[-1].box_index
+                        and sent.page_no == current[-1].page_no):
                     # Find where this box_index started in current
                     bi = sent.box_index
                     pg = sent.page_no
@@ -187,7 +197,9 @@ class ChunkAssembler:
                     while j > 0 and current[j].box_index == bi and current[j].page_no == pg:
                         j -= 1
                     if j > 0:  # don't empty the entire current
-                        split_point = j + 1
+                        carry_tokens = sum(s.token_count for s in current[j + 1:])
+                        if carry_tokens + sent.token_count <= self.max_tokens:
+                            split_point = j + 1
 
                 keep = current[:split_point]
                 carry = current[split_point:]
@@ -245,6 +257,13 @@ class ChunkAssembler:
         """Check if (a, b) form a semantic pair that should stay together."""
         if a.primary_type == "header_footer" or b.primary_type == "header_footer":
             return False
+        # A chunk *opening* with a heading is a section start. primary_type
+        # is "heading" only for lone headings, so without this a lone parent
+        # heading would swallow the following "child heading + body" chunk
+        # and cross the section boundary respect_section_starts protects.
+        if (self.respect_section_starts and b._sentences
+                and b._sentences[0].is_heading_hint):
+            return False
         if a.token_count + b.token_count > self.max_tokens:
             return False
         if abs(a.page_end - b.page_start) > 1:
@@ -286,7 +305,7 @@ class ChunkAssembler:
     # ── Budget merge ─────────────────────────────────────────────────
 
     def _merge_budget(self, chunks: list[ProtoChunk]) -> list[ProtoChunk]:
-        """Greedily merge adjacent chunks that fit within max_tokens.
+        """Merge adjacent undersized chunks that fit within max_tokens.
 
         Preserves bbox structure from earlier phases: instead of rebuilding
         bboxes from scratch, concatenates the bbox lists of both chunks.
@@ -319,6 +338,11 @@ class ChunkAssembler:
         Spatial proximity (bbox overlap, page distance) is intentionally
         NOT checked here — budget merge is purely about filling token
         capacity with sequentially adjacent chunks.
+
+        min_tokens is the floor this step works towards: a pair is merged
+        only while at least one side is still below it, so two chunks that
+        already stand on their own are left alone (merge_small_chunks
+        semantics).  min_tokens=0 restores unconditional greedy packing.
         """
         if a.primary_type == "header_footer" or b.primary_type == "header_footer":
             return False
@@ -337,6 +361,11 @@ class ChunkAssembler:
             if a.primary_type == "table" or b.primary_type == "table":
                 return False
         if a.token_count + b.token_count > self.max_tokens:
+            return False
+        # Nothing to gain: both sides already reach the floor.
+        if (self.min_tokens > 0
+                and a.token_count >= self.min_tokens
+                and b.token_count >= self.min_tokens):
             return False
         return True
 

--- a/src/helpers/chunking/chunked_document.py
+++ b/src/helpers/chunking/chunked_document.py
@@ -1,0 +1,262 @@
+"""ChunkedDocument: the return type of to_chunks.
+
+A Sequence[Chunk] carrying the element registry, the table/figure/section
+views (bidirectionally linked to chunks), a section hierarchy tree,
+ingestion diagnostics, and cheap re-chunking from retained units.
+"""
+
+import json
+from collections.abc import Sequence
+from dataclasses import fields
+from types import MappingProxyType
+
+from .models import SectionNode
+
+# Assembly-tier parameters reassemble_chunks() can honor from retained units (D11).
+# Everything else (sentence_splitter, header_footer_mode, tokenizer,
+# weights, parse options) changes the substrate and requires a new
+# to_chunks() call.
+REASSEMBLY_PARAMS = frozenset({
+    "max_tokens",
+    "min_tokens",
+    "breakpoint_threshold",
+    "table_mode",
+    "merge_small_chunks",
+    "respect_section_starts",
+})
+
+_MISSING = object()
+
+
+class ChunkedDocument(Sequence):
+    """Retrieval-ready chunks plus document-level structure.
+
+    - Sequence protocol: ``len(cd)``, ``cd[i]``, iteration, slicing.
+    - ``elements``: every layout box the parser saw (header/footer included),
+      addressable as ``p{page}.b{box}``.
+    - ``tables`` / ``figures`` / ``sections``: views linked to chunks both
+      ways (view.chunk_id(s) <-> chunk.metadata.table_ids/figure_ids/
+      section_id).
+    - ``hierarchy``: sections as a tree of SectionNode (root level 0).
+    - ``diagnostics``: structured input for an ingestion gate.
+    """
+
+    def __init__(self, chunks, *, elements=(), tables=(), figures=(),
+                 sections=(), params=None, doc=None, all_units=(),
+                 header_footer_excluded=0):
+        self._chunks = tuple(chunks)
+        self.elements = list(elements)
+        self.tables = list(tables)
+        self.figures = list(figures)
+        self.sections = list(sections)
+        self.params = MappingProxyType(dict(params or {}))
+        self._doc = doc
+        self._all_units = list(all_units)
+        self._header_footer_excluded = header_footer_excluded
+        self._text = None
+        self._by_id = None
+        self._hierarchy = None
+
+        # Bind section element spans to the registry so SectionChunk.text
+        # can assemble lazily.
+        for s in self.sections:
+            lo, hi = s.element_span
+            s._elements = tuple(self.elements[lo:hi])
+
+    # ── Sequence protocol ───────────────────────────────────────────
+
+    def __len__(self):
+        return len(self._chunks)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return list(self._chunks[index])
+        return self._chunks[index]
+
+    def __repr__(self):
+        return (f"ChunkedDocument(chunks={len(self._chunks)}, "
+                f"tables={len(self.tables)}, figures={len(self.figures)}, "
+                f"sections={len(self.sections)})")
+
+    @property
+    def chunks(self) -> tuple:
+        """The chunks as a tuple (== tuple(self)); explicit-access form."""
+        return self._chunks
+
+    # ── Lazy document text ──────────────────────────────────────────
+
+    @property
+    def text(self) -> str:
+        """All chunk text joined in reading order (lazy, cached)."""
+        if self._text is None:
+            self._text = "\n\n".join(c.text for c in self._chunks)
+        return self._text
+
+    # ── Section hierarchy tree ──────────────────────────────────────
+
+    @property
+    def hierarchy(self) -> SectionNode:
+        """Sections nested as a tree; the root node has level 0."""
+        if self._hierarchy is None:
+            root = SectionNode()
+            stack = [root]
+            for s in self.sections:
+                node = SectionNode(title=s.title, level=s.level,
+                                   section_id=s.id)
+                while len(stack) > 1 and stack[-1].level >= s.level:
+                    stack.pop()
+                stack[-1].children.append(node)
+                stack.append(node)
+            self._hierarchy = root
+        return self._hierarchy
+
+    # ── Addressing ──────────────────────────────────────────────────
+
+    def get(self, id: str, default=_MISSING):
+        """Look up any public id: c{n}, t{n}, f{n}, s{n}, p{page}.b{box}.
+
+        Raises KeyError for an unknown id unless *default* is given.
+        """
+        if self._by_id is None:
+            index = {}
+            for c in self._chunks:
+                index[c.id] = c
+            for group in (self.tables, self.figures, self.sections):
+                for item in group:
+                    index[item.id] = item
+            for el in self.elements:
+                index[el.id] = el
+            self._by_id = index
+
+        found = self._by_id.get(id, _MISSING) if id else _MISSING
+        if found is _MISSING:
+            if default is _MISSING:
+                raise KeyError(id)
+            return default
+        return found
+
+    # ── Contextual text ─────────────────────────────────────────────
+
+    def contextualize(self, chunk) -> str:
+        """Context-enriched text for a chunk (== chunk.contextual_text)."""
+        return chunk.contextual_text
+
+    # ── Serialization ───────────────────────────────────────────────
+
+    def to_dicts(self, *, include_contextual: bool = True) -> list:
+        """Chunks as flat, json-safe, payload-ready dicts (schema §4.5)."""
+        return [_chunk_to_dict(c, include_contextual) for c in self._chunks]
+
+    def to_json(self, *, include_contextual: bool = True, **json_kwargs) -> str:
+        json_kwargs.setdefault("default", _json_default)
+        return json.dumps(
+            self.to_dicts(include_contextual=include_contextual),
+            **json_kwargs,
+        )
+
+    # ── Re-assembly (assembly tier, from retained units) ────────────
+
+    def reassemble_chunks(self, **params):
+        """Re-run assembly from retained units with new budget params.
+
+        Only assembly-tier parameters are accepted (REASSEMBLY_PARAMS);
+        substrate parameters (sentence_splitter, header_footer_mode,
+        tokenizer, weights) and parse options raise ValueError — call
+        to_chunks() on a new parse for those.
+        """
+        unknown = set(params) - REASSEMBLY_PARAMS
+        if unknown:
+            raise ValueError(
+                f"reassemble_chunks only accepts {sorted(REASSEMBLY_PARAMS)}; "
+                f"{sorted(unknown)} require a new to_chunks() call"
+            )
+        from . import _chunk_units
+
+        merged = {**self.params, **params}
+        return _chunk_units(self._doc, self._all_units, merged)
+
+    # ── Diagnostics (D16) ───────────────────────────────────────────
+
+    @property
+    def diagnostics(self) -> dict:
+        """Structured ingestion-gate input, derived from the registry.
+
+        Consumers decide PROCEED/HOLD/REJECT; this only reports facts:
+        counts, zero-chunk causes, text-less figures (OCR candidates),
+        degenerate tables, and header/footer exclusions.
+        """
+        pages = [p.page_number for p in self._doc.pages] if self._doc else []
+        pages_with_chunks = set()
+        for c in self._chunks:
+            pages_with_chunks.update(
+                range(c.metadata.page_start, c.metadata.page_end + 1))
+
+        zero_chunk_causes = []
+        if not self._chunks:
+            if not self._all_units:
+                zero_chunk_causes.append("no_text_extracted")
+            elif all(u.is_header_footer for u in self._all_units):
+                zero_chunk_causes.append("all_units_header_footer")
+            else:
+                zero_chunk_causes.append("all_units_filtered")
+
+        return {
+            "chunk_count": len(self._chunks),
+            "element_count": len(self.elements),
+            "table_count": len(self.tables),
+            "figure_count": len(self.figures),
+            "section_count": len(self.sections),
+            "page_count": len(pages),
+            "pages_without_chunks": sorted(set(pages) - pages_with_chunks),
+            "zero_chunk_causes": zero_chunk_causes,
+            "figures_without_text": [f.id for f in self.figures
+                                     if not f.has_text],
+            "degenerate_tables": [t.id for t in self.tables
+                                  if not t.text.strip()],
+            "header_footer_excluded": self._header_footer_excluded,
+        }
+
+    # ── Framework exports (stretch, import-guarded) ─────────────────
+
+    def to_langchain_documents(self):
+        """Chunks as langchain Documents (requires langchain-core)."""
+        from langchain_core.documents import Document
+
+        return [
+            Document(page_content=c.text,
+                     metadata=_chunk_to_dict(c, False)["metadata"])
+            for c in self._chunks
+        ]
+
+    def to_llama_nodes(self):
+        """Chunks as llama-index TextNodes (requires llama-index-core)."""
+        from llama_index.core.schema import TextNode
+
+        return [
+            TextNode(id_=c.id, text=c.text,
+                     metadata=_chunk_to_dict(c, False)["metadata"])
+            for c in self._chunks
+        ]
+
+
+def _chunk_to_dict(chunk, include_contextual: bool) -> dict:
+    d = {
+        "id": chunk.id,
+        "text": chunk.text,
+        "content_hash": chunk.content_hash,
+        "metadata": {
+            f.name: getattr(chunk.metadata, f.name)
+            for f in fields(chunk.metadata)
+        },
+    }
+    if include_contextual:
+        d["contextual_text"] = chunk.contextual_text
+    return d
+
+
+def _json_default(o):
+    if isinstance(o, bytes):
+        return None  # images are not serialized into JSON
+    if isinstance(o, tuple):
+        return list(o)
+    raise TypeError(f"not JSON serializable: {type(o)!r}")

--- a/src/helpers/chunking/chunked_document.py
+++ b/src/helpers/chunking/chunked_document.py
@@ -135,22 +135,16 @@ class ChunkedDocument(Sequence):
             return default
         return found
 
-    # ── Contextual text ─────────────────────────────────────────────
-
-    def contextualize(self, chunk) -> str:
-        """Context-enriched text for a chunk (== chunk.contextual_text)."""
-        return chunk.contextual_text
-
     # ── Serialization ───────────────────────────────────────────────
 
-    def to_dicts(self, *, include_contextual: bool = True) -> list:
+    def to_dicts(self, *, include_tagged: bool = True) -> list:
         """Chunks as flat, json-safe, payload-ready dicts (schema §4.5)."""
-        return [_chunk_to_dict(c, include_contextual) for c in self._chunks]
+        return [_chunk_to_dict(c, include_tagged) for c in self._chunks]
 
-    def to_json(self, *, include_contextual: bool = True, **json_kwargs) -> str:
+    def to_json(self, *, include_tagged: bool = True, **json_kwargs) -> str:
         json_kwargs.setdefault("default", _json_default)
         return json.dumps(
-            self.to_dicts(include_contextual=include_contextual),
+            self.to_dicts(include_tagged=include_tagged),
             **json_kwargs,
         )
 
@@ -239,7 +233,7 @@ class ChunkedDocument(Sequence):
         ]
 
 
-def _chunk_to_dict(chunk, include_contextual: bool) -> dict:
+def _chunk_to_dict(chunk, include_tagged: bool) -> dict:
     d = {
         "id": chunk.id,
         "text": chunk.text,
@@ -249,8 +243,8 @@ def _chunk_to_dict(chunk, include_contextual: bool) -> dict:
             for f in fields(chunk.metadata)
         },
     }
-    if include_contextual:
-        d["contextual_text"] = chunk.contextual_text
+    if include_tagged:
+        d["tagged_content"] = chunk.tagged_content
     return d
 
 

--- a/src/helpers/chunking/chunked_document.py
+++ b/src/helpers/chunking/chunked_document.py
@@ -182,8 +182,7 @@ class ChunkedDocument(Sequence):
         pages = [p.page_number for p in self._doc.pages] if self._doc else []
         pages_with_chunks = set()
         for c in self._chunks:
-            pages_with_chunks.update(
-                range(c.metadata.page_start, c.metadata.page_end + 1))
+            pages_with_chunks.update(_chunk_pages(c))
 
         zero_chunk_causes = []
         if not self._chunks:
@@ -212,25 +211,71 @@ class ChunkedDocument(Sequence):
 
     # ── Framework exports (stretch, import-guarded) ─────────────────
 
-    def to_langchain_documents(self):
-        """Chunks as langchain Documents (requires langchain-core)."""
+    def to_langchain_documents(self, *, doc_id: str | None = None):
+        """Chunks as langchain Documents (requires langchain-core).
+
+        See :meth:`to_llama_nodes` for what *doc_id* is for.
+        """
         from langchain_core.documents import Document
 
         return [
-            Document(page_content=c.text,
-                     metadata=_chunk_to_dict(c, False)["metadata"])
+            Document(id=_export_id(c.id, doc_id),
+                     page_content=c.text,
+                     metadata=_export_metadata(c))
             for c in self._chunks
         ]
 
-    def to_llama_nodes(self):
-        """Chunks as llama-index TextNodes (requires llama-index-core)."""
+    def to_llama_nodes(self, *, doc_id: str | None = None):
+        """Chunks as llama-index TextNodes (requires llama-index-core).
+
+        Chunk ids are document-local ("c0" starts every document), so two
+        documents in one store collide on the exported id and the later
+        write replaces the earlier record. Pass *doc_id* — any stable
+        per-document key — to export ``"{doc_id}:{chunk.id}"`` instead.
+
+        The chunk's own id is always in ``metadata["chunk_id"]``, so a
+        retrieved record still addresses ``ChunkedDocument.get()``.
+        """
         from llama_index.core.schema import TextNode
 
         return [
-            TextNode(id_=c.id, text=c.text,
-                     metadata=_chunk_to_dict(c, False)["metadata"])
+            TextNode(id_=_export_id(c.id, doc_id), text=c.text,
+                     metadata=_export_metadata(c))
             for c in self._chunks
         ]
+
+
+def _export_id(chunk_id: str, doc_id) -> str:
+    """Store-facing id: document-scoped when a doc_id is given."""
+    return f"{doc_id}:{chunk_id}" if doc_id else chunk_id
+
+
+def _export_metadata(chunk) -> dict:
+    """Framework metadata: the ChunkMetadata fields plus the chunk id."""
+    metadata = _chunk_to_dict(chunk, False)["metadata"]
+    metadata["chunk_id"] = chunk.id
+    return metadata
+
+
+def _chunk_pages(chunk) -> set:
+    """Pages that actually put content into *chunk*.
+
+    ``page_start..page_end`` is a span, not a coverage claim: a chunk
+    bridging pages 1 and 3 says nothing about page 2, so counting the span
+    would hide an empty page from ``pages_without_chunks``. The pages come
+    from the chunk's own bbox/element addresses instead.
+    """
+    pages = {b[0] for b in chunk.metadata.bboxes if b}
+    for element in chunk.metadata.element_ids:
+        page = element.partition(".b")[0]
+        try:
+            pages.add(int(page[1:]))
+        except ValueError:
+            continue
+    if not pages:
+        pages = set(range(chunk.metadata.page_start,
+                          chunk.metadata.page_end + 1))
+    return pages
 
 
 def _chunk_to_dict(chunk, include_tagged: bool) -> dict:

--- a/src/helpers/chunking/models.py
+++ b/src/helpers/chunking/models.py
@@ -99,7 +99,7 @@ class ProtoChunk:
     bboxes: list = field(default_factory=list)  # list of (page, x0, y0, x1, y1)
 
     # Structure
-    chunk_type_hint: Optional[str] = None  # primary type: paragraph, table, list, figure, ...
+    primary_type: Optional[str] = None  # primary type: paragraph, table, list, figure, ...
     types: list = field(default_factory=list)  # all types present, e.g. ["heading", "table"]
 
     # References to SentenceUnits (kept for split/merge)
@@ -243,7 +243,7 @@ class Chunk:
     """A finalized, retrieval-ready chunk."""
     id: str                    # "c{n}" (budget-local: changes across reassemble_chunks)
     text: str
-    contextual_text: str = ""
+    tagged_content: str = ""
     metadata: ChunkMetadata = field(default_factory=ChunkMetadata)
 
     _content_hash: Optional[str] = field(default=None, repr=False, compare=False)

--- a/src/helpers/chunking/models.py
+++ b/src/helpers/chunking/models.py
@@ -1,0 +1,375 @@
+"""Data models for the chunking pipeline.
+
+ID formats are a public contract (stable across versions, snapshot-tested):
+
+- element:  ``p{page}.b{box}``  (1-based original page number, 0-based box
+  index on that page).  Element ids are scoped to (document bytes, package
+  version, parse options): parse modes that re-split boxes (e.g. HTML table
+  rendering) produce different box indices, so ids must not be cached
+  across parse-option changes.
+- chunk:    ``c{n}``
+- table:    ``t{n}``
+- figure:   ``f{n}``  (same numbering as ``[Figure f{n}: WxH]`` placeholders)
+- section:  ``s{n}``
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+def element_id(page: int, box: int) -> str:
+    """Public element id: 'p{page}.b{box}'."""
+    return f"p{page}.b{box}"
+
+
+@dataclass
+class SentenceUnit:
+    """A sentence-level unit extracted from a LayoutBox.
+
+    For table/figure boxes, this represents the entire box content as one unit.
+    """
+    sent_id: int
+    text: str
+    norm_text: str
+
+    # Location
+    page_no: int
+    box_index: int
+    boxclass: str
+    bbox: tuple  # (x0, y0, x1, y1)
+
+    # Token count (precomputed once by the pipeline; see CumulativeCounter)
+    token_count: int = 0
+
+    # Font metrics (from dominant span)
+    font_size_dominant: float = 0.0
+    font_flags_dominant: int = 0
+
+    # Vertical spacing
+    line_gap_before: Optional[float] = None
+    line_gap_after: Optional[float] = None
+
+    # Structure hints (derived from LayoutBox.boxclass)
+    is_heading_hint: bool = False
+    heading_level_hint: Optional[int] = None
+    is_list_item: bool = False
+    is_table_content: bool = False
+    is_figure_related: bool = False
+    is_footnote: bool = False
+    is_header_footer: bool = False
+    is_caption: bool = False
+    caption_target_type: Optional[str] = None  # "table", "figure", None
+
+    # Original table content (when is_table_content=True). Exactly one of
+    # markdown/html is set, matching the parse mode (html mode carries
+    # markdown=None); the unit's text holds the canonical rendering.
+    table_markdown: Optional[str] = None
+    table_html: Optional[str] = None
+
+    # Document-wide figure sequence number (when is_figure_related=True)
+    figure_number: Optional[int] = None
+
+    # Image bytes (when is_figure_related=True and extract_images=True)
+    image_data: Optional[bytes] = field(default=None, repr=False)
+
+    # Tracks original box indices when multiple HF units are merged
+    _source_box_indices: list = field(default_factory=list, repr=False)
+
+
+# Internal alias: pipeline units (the v2 name; SentenceUnit kept for compat)
+Unit = SentenceUnit
+
+
+@dataclass
+class ProtoChunk:
+    """An intermediate chunk before split/merge refinement.
+
+    Holds a contiguous run of units; ``text`` is only materialized at
+    serialization time (``unit_range`` + precomputed token sums keep
+    assembly free of repeated joining/tokenizing).
+    """
+    chunk_id: int
+    sent_ids: list = field(default_factory=list)
+    text: str = ""
+    token_count: int = 0
+    unit_range: tuple = (0, 0)  # [start, end) over the working unit list
+
+    # Location
+    page_start: int = 0
+    page_end: int = 0
+    box_indices: list = field(default_factory=list)  # [(page_no, box_index), ...]
+    bboxes: list = field(default_factory=list)  # list of (page, x0, y0, x1, y1)
+
+    # Structure
+    chunk_type_hint: Optional[str] = None  # primary type: paragraph, table, list, figure, ...
+    chunk_types: list = field(default_factory=list)  # all types present, e.g. ["heading", "table"]
+
+    # References to SentenceUnits (kept for split/merge)
+    _sentences: list = field(default_factory=list, repr=False)
+
+
+@dataclass(frozen=True)
+class Element:
+    """One layout box, chunk-addressable evidence with canonical text.
+
+    The registry keeps every box — including header/footer boxes excluded
+    from chunk text — so nothing the parser saw is unreachable (D8).
+    """
+    id: str        # element_id(page, box) — public contract
+    page: int
+    box: int
+    boxclass: str
+    bbox: tuple    # (x0, y0, x1, y1)
+    text: str      # canonical markdown rendering ("" when nothing renders)
+    is_header_footer: bool = False
+
+
+@dataclass
+class TableChunk:
+    """A table exposed in the tables view; links back to its chunk.
+
+    ``markdown`` and ``html`` are mutually exclusive per parse mode: in
+    HTML table mode the parser carries markdown=None and html is the
+    canonical rendering; otherwise markdown is canonical (possibly ``""``
+    for a degenerate table) and html is None (D15).
+    """
+    id: str                    # "t{n}"
+    chunk_id: Optional[str]    # owning chunk id ("c{n}"), None if unchunked
+    element_id: str
+    page: int
+    bbox: tuple
+    markdown: Optional[str] = None
+    html: Optional[str] = None
+    headers: list = field(default_factory=list)  # header cell texts (from <th>)
+    caption: Optional[str] = None
+    caption_element_id: Optional[str] = None
+    section_id: Optional[str] = None             # "s{n}" of innermost section
+    token_count: int = 0
+
+    @property
+    def text(self) -> str:
+        """Canonical rendering for the parse mode."""
+        if self.html is not None:
+            return self.html
+        return self.markdown or ""
+
+
+@dataclass
+class FigureChunk:
+    """A figure/formula exposed in the figures view; links back to its chunk."""
+    id: str                    # "f{n}"
+    chunk_id: Optional[str]
+    element_id: str
+    page: int
+    bbox: tuple                # re-render address for vision pipelines
+    boxclass: str = "picture"
+    ocr_text: Optional[str] = None  # text extracted inside the figure (None → OCR candidate)
+    placeholder: str = ""      # "[Figure f{n}: WxH]" when the figure has no text
+    caption: Optional[str] = None
+    caption_element_id: Optional[str] = None
+    section_id: Optional[str] = None
+    image: Optional[bytes] = field(default=None, repr=False)
+
+    @property
+    def has_text(self) -> bool:
+        return bool(self.ocr_text and self.ocr_text.strip())
+
+
+@dataclass
+class SectionChunk:
+    """A section (heading span) exposed in the sections view."""
+    id: str                    # "s{n}"
+    title: str
+    level: int
+    page_start: int
+    page_end: int
+    heading_element_id: Optional[str] = None
+    path: list = field(default_factory=list)       # titles, root → self
+    element_span: tuple = (0, 0)                   # [start, end) into ChunkedDocument.elements
+    child_chunk_ids: list = field(default_factory=list)  # chunks under this section
+    token_count: int = 0                           # sum over child chunks
+
+    _elements: tuple = field(default=(), repr=False, compare=False)
+
+    @property
+    def text(self) -> str:
+        """Section body text, assembled lazily from the element registry."""
+        return "\n\n".join(
+            e.text for e in self._elements
+            if e.text and not e.is_header_footer
+        )
+
+
+@dataclass
+class SectionNode:
+    """A node in ChunkedDocument.hierarchy (root has level 0, no section)."""
+    title: str = ""
+    level: int = 0
+    section_id: Optional[str] = None
+    children: list = field(default_factory=list)
+
+
+@dataclass
+class ChunkMetadata:
+    """Metadata attached to a final chunk (payload-ready: every field is
+    json-safe and lands in ``to_dicts()`` as-is)."""
+    page_start: int = 0
+    page_end: int = 0
+    bboxes: list = field(default_factory=list)  # list of (page, x0, y0, x1, y1)
+    chunk_type: str = "paragraph"               # primary type
+    chunk_types: list = field(default_factory=list)  # all types present, in order
+    section_id: Optional[str] = None                 # "s{n}" of innermost section
+    section_path: list = field(default_factory=list)  # human-facing citation path
+    token_count: int = 0
+    element_ids: list = field(default_factory=list)   # ["p{page}.b{box}", ...]
+
+    # Bidirectional links into the document views
+    table_ids: list = field(default_factory=list)    # ["t0", ...]
+    figure_ids: list = field(default_factory=list)   # ["f1", ...]
+
+    # Logical list groups within this chunk
+    lists: list = field(default_factory=list)
+
+    # Source pages went through OCR
+    ocr: bool = False
+
+    # Document provenance
+    file_path: Optional[str] = None
+    page_count: Optional[int] = None
+
+    @property
+    def section_hierarchy(self) -> list:
+        """Pre-rename alias of section_path."""
+        return self.section_path
+
+    @property
+    def chunk_type_hint(self) -> str:
+        """Pre-rename alias of chunk_type."""
+        return self.chunk_type
+
+
+_WS_RE = re.compile(r"\s+")
+
+
+@dataclass
+class Chunk:
+    """A finalized, retrieval-ready chunk."""
+    id: str                    # "c{n}" (budget-local: changes across reassemble_chunks)
+    text: str
+    contextual_text: str = ""
+    metadata: ChunkMetadata = field(default_factory=ChunkMetadata)
+
+    _content_hash: Optional[str] = field(default=None, repr=False, compare=False)
+
+    @property
+    def chunk_id(self) -> str:
+        """Pre-rename alias of id."""
+        return self.id
+
+    @property
+    def content_hash(self) -> str:
+        """Lazy sha256 of whitespace-normalized text (D17).
+
+        Stable across runs for identical content; whitespace-normalized so
+        that byte-identical content is not reported as changed by
+        rendering-neutral whitespace drift.
+        """
+        if self._content_hash is None:
+            norm = _WS_RE.sub(" ", self.text).strip()
+            self._content_hash = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        return self._content_hash
+
+
+# Backward-compatible alias (pre-rename name)
+FinalChunk = Chunk
+
+
+def caption_matches_element(caption, element) -> bool:
+    """Check if a caption SentenceUnit matches an element SentenceUnit (one direction).
+
+    Returns True if caption targets the element type, or if target_type is None
+    and element is table/figure/list.
+    """
+    if not caption.is_caption:
+        return False
+    if not (element.is_table_content or element.is_figure_related or element.is_list_item):
+        return False
+    if caption.caption_target_type is None:
+        return True
+    if caption.caption_target_type == "table" and element.is_table_content:
+        return True
+    if caption.caption_target_type == "figure" and element.is_figure_related:
+        return True
+    return False
+
+
+def horizontal_overlap_ratio(bbox_a: tuple, bbox_b: tuple) -> float:
+    """Compute horizontal overlap ratio between two bboxes.
+
+    Returns overlap / min_width, or 1.0 if either bbox has zero width.
+    """
+    ax0, _, ax1, _ = bbox_a
+    bx0, _, bx1, _ = bbox_b
+    min_width = min(ax1 - ax0, bx1 - bx0)
+    if min_width <= 0:
+        return 1.0
+    overlap = max(0.0, min(ax1, bx1) - max(ax0, bx0))
+    return overlap / min_width
+
+
+def union_bbox(bboxes) -> tuple:
+    """Compute the union bounding box from an iterable of (x0, y0, x1, y1) tuples."""
+    x0 = y0 = float('inf')
+    x1 = y1 = float('-inf')
+    for bx0, by0, bx1, by1 in bboxes:
+        x0 = min(x0, bx0)
+        y0 = min(y0, by0)
+        x1 = max(x1, bx1)
+        y1 = max(y1, by1)
+    if x0 == float('inf'):
+        return (0, 0, 0, 0)
+    return (x0, y0, x1, y1)
+
+
+def _has_shared_edge(bbox_a: tuple, bbox_b: tuple, tol: float) -> bool:
+    """Check if two bboxes share a matching edge *pair*.
+
+    Returns True when (x0 AND x1) or (y0 AND y1) both match within *tol*.
+    A single edge match (e.g. only x1) is not enough — it would cause
+    chain-reaction grouping across spatially unrelated boxes.
+    """
+    ax0, ay0, ax1, ay1 = bbox_a
+    bx0, by0, bx1, by1 = bbox_b
+    x_pair = abs(ax0 - bx0) <= tol and abs(ax1 - bx1) <= tol
+    y_pair = abs(ay0 - by0) <= tol and abs(ay1 - by1) <= tol
+    return x_pair or y_pair
+
+
+def group_bboxes(bboxes, tolerance: float = 10.0) -> list[tuple]:
+    """Group sequential bboxes that share a matching edge pair.
+
+    Only the *last* (most recent) group is checked for each incoming box.
+    If it doesn't match, a new group is created.  This respects reading
+    order: once a spatially different region appears (e.g. an indented
+    code block), subsequent boxes continue from that break rather than
+    jumping back to an earlier group.
+
+    *tolerance* defaults to 10 PDF points (~3.5 mm at 72 dpi).
+    """
+    boxes = list(bboxes)
+    if not boxes:
+        return []
+    if len(boxes) == 1:
+        return list(boxes)
+
+    groups: list[list[tuple]] = [[boxes[0]]]
+    for box in boxes[1:]:
+        last_union = union_bbox(iter(groups[-1]))
+        if _has_shared_edge(last_union, box, tolerance):
+            groups[-1].append(box)
+        else:
+            groups.append([box])
+
+    return [union_bbox(iter(g)) for g in groups]

--- a/src/helpers/chunking/models.py
+++ b/src/helpers/chunking/models.py
@@ -78,10 +78,6 @@ class SentenceUnit:
     _source_box_indices: list = field(default_factory=list, repr=False)
 
 
-# Internal alias: pipeline units (the v2 name; SentenceUnit kept for compat)
-Unit = SentenceUnit
-
-
 @dataclass
 class ProtoChunk:
     """An intermediate chunk before split/merge refinement.
@@ -104,7 +100,7 @@ class ProtoChunk:
 
     # Structure
     chunk_type_hint: Optional[str] = None  # primary type: paragraph, table, list, figure, ...
-    chunk_types: list = field(default_factory=list)  # all types present, e.g. ["heading", "table"]
+    types: list = field(default_factory=list)  # all types present, e.g. ["heading", "table"]
 
     # References to SentenceUnits (kept for split/merge)
     _sentences: list = field(default_factory=list, repr=False)
@@ -218,8 +214,7 @@ class ChunkMetadata:
     page_start: int = 0
     page_end: int = 0
     bboxes: list = field(default_factory=list)  # list of (page, x0, y0, x1, y1)
-    chunk_type: str = "paragraph"               # primary type
-    chunk_types: list = field(default_factory=list)  # all types present, in order
+    types: list = field(default_factory=list)   # element types present, in order
     section_id: Optional[str] = None                 # "s{n}" of innermost section
     section_path: list = field(default_factory=list)  # human-facing citation path
     token_count: int = 0
@@ -239,16 +234,6 @@ class ChunkMetadata:
     file_path: Optional[str] = None
     page_count: Optional[int] = None
 
-    @property
-    def section_hierarchy(self) -> list:
-        """Pre-rename alias of section_path."""
-        return self.section_path
-
-    @property
-    def chunk_type_hint(self) -> str:
-        """Pre-rename alias of chunk_type."""
-        return self.chunk_type
-
 
 _WS_RE = re.compile(r"\s+")
 
@@ -264,11 +249,6 @@ class Chunk:
     _content_hash: Optional[str] = field(default=None, repr=False, compare=False)
 
     @property
-    def chunk_id(self) -> str:
-        """Pre-rename alias of id."""
-        return self.id
-
-    @property
     def content_hash(self) -> str:
         """Lazy sha256 of whitespace-normalized text (D17).
 
@@ -280,10 +260,6 @@ class Chunk:
             norm = _WS_RE.sub(" ", self.text).strip()
             self._content_hash = hashlib.sha256(norm.encode("utf-8")).hexdigest()
         return self._content_hash
-
-
-# Backward-compatible alias (pre-rename name)
-FinalChunk = Chunk
 
 
 def caption_matches_element(caption, element) -> bool:

--- a/src/helpers/chunking/models.py
+++ b/src/helpers/chunking/models.py
@@ -240,7 +240,17 @@ _WS_RE = re.compile(r"\s+")
 
 @dataclass
 class Chunk:
-    """A finalized, retrieval-ready chunk."""
+    """A finalized, retrieval-ready chunk.
+
+    Treat a chunk as read-only once ``to_chunks()`` has returned it.
+    ``content_hash`` is computed once and cached, and
+    ``ChunkedDocument.text`` / ``ChunkedDocument.get()`` cache over the
+    chunk list, so assigning to ``text`` (or mutating ``metadata``) leaves
+    those caches describing the previous content. To change chunk
+    boundaries call ``reassemble_chunks()``; to carry your own fields,
+    keep them beside the chunk (its id is the stable key) rather than on
+    it.
+    """
     id: str                    # "c{n}" (budget-local: changes across reassemble_chunks)
     text: str
     tagged_content: str = ""

--- a/src/helpers/chunking/sentence_builder.py
+++ b/src/helpers/chunking/sentence_builder.py
@@ -1,0 +1,498 @@
+"""Step A: Convert LayoutBox textlines into SentenceUnits."""
+
+import re
+from collections import Counter, defaultdict
+from typing import Optional
+
+from .models import SentenceUnit, union_bbox
+from .text_source import (
+    box_to_markdown,
+    create_list_item_levels,
+    figure_placeholder,
+    table_content,
+)
+
+# Sentence-ending patterns
+_SENT_END_EN = re.compile(
+    r'(?<=[.!?])'        # after sentence-ending punctuation
+    r'(?:\s*["\'\)\]]*)'  # optional closing quotes/brackets
+    r'\s+'                # followed by whitespace
+    r'(?=[A-Z"\'\(\[])'   # before uppercase or opening quote/bracket
+)
+
+_SENT_END_MULTI = re.compile(
+    r'(?<=[.!?。！？])'
+    r'(?:\s*["\'\)\]」』]*)'
+    r'\s*'
+    r'(?=[A-Z가-힣ㄱ-ㅎㅏ-ㅣ一-鿿"\'\(\[「『]|$)'
+)
+
+# Whitespace normalization
+_MULTI_SPACE = re.compile(r'[ \t]+')
+
+# Leading markdown decoration (heading marks, styles, quotes)
+_MD_DECORATION = re.compile(r'^[#>*_`\s]+')
+
+# Caption detection patterns
+_CAPTION_PATTERNS = [
+    re.compile(r'^(?:figure|fig\.?\s*)\s*\d+(?:[.\-]\d+)*', re.IGNORECASE),
+    re.compile(r'^(?:table|tbl\.?\s*)\s*\d+(?:[.\-]\d+)*', re.IGNORECASE),
+    re.compile(r'^\(\s*[a-z0-9]\s*\)', re.IGNORECASE),
+    re.compile(r'^(?:source|notes?)\s*:', re.IGNORECASE),
+]
+
+
+def _detect_caption(text: str) -> tuple[bool, Optional[str]]:
+    """Detect if text is a caption and determine target type.
+
+    Returns (is_caption, target_type) where target_type is "figure", "table", or None.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False, None
+
+    for pat in _CAPTION_PATTERNS:
+        if pat.search(stripped):
+            low = stripped.lower()
+            if low.startswith(("figure", "fig")):
+                return True, "figure"
+            if low.startswith(("table", "tbl")):
+                return True, "table"
+            return True, None
+
+    return False, None
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize text for comparison: lowercase, collapse whitespace."""
+    t = text.strip().lower()
+    t = _MULTI_SPACE.sub(' ', t)
+    return t
+
+
+def _strip_md_decoration(text: str) -> str:
+    """Strip leading markdown decoration for pattern matching (captions, TOC)."""
+    return _MD_DECORATION.sub('', text)
+
+
+def _get_dominant_font(textlines: list[dict]) -> tuple[float, int]:
+    """Get the most common (font_size, font_flags) from spans by character count."""
+    font_counter = Counter()
+    for tl in textlines:
+        for span in tl.get("spans", []):
+            text = span.get("text", "")
+            char_count = len(text.strip())
+            if char_count > 0:
+                size = round(span.get("size", 0), 1)
+                flags = span.get("flags", 0)
+                font_counter[(size, flags)] += char_count
+
+    if not font_counter:
+        return 0.0, 0
+
+    (size, flags), _ = font_counter.most_common(1)[0]
+    return size, flags
+
+
+def _compute_bbox_union(textlines: list[dict]) -> tuple:
+    """Compute the union bounding box of all textlines."""
+    def _iter_bboxes():
+        for tl in textlines:
+            bbox = tl.get("bbox")
+            if bbox is None:
+                continue
+            try:
+                yield (float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3]))
+            except (TypeError, IndexError):
+                continue
+    return union_bbox(_iter_bboxes())
+
+
+def _boxclass_to_hints(boxclass: str, toc=None, page_no=None, text=None,
+                       header_level=None):
+    """Map LayoutBox.boxclass to structure hint flags.
+
+    Returns only non-default values (SentenceUnit defaults handle the rest).
+
+    Heading depth comes first from the engine's font-statistics assignment
+    (LayoutBox.header_level, the same value the markdown renderers use for
+    #/##/### depth), so the section hierarchy nests the way the rendered
+    text does. The TOC match is a fallback for boxes the engine left
+    unleveled.
+    """
+    if boxclass == "title":
+        return {"is_heading_hint": True,
+                "heading_level_hint": header_level or 1}
+    if boxclass == "section-header":
+        level = header_level or (
+            _match_toc_level(toc, page_no, text) if toc and text else None)
+        return {"is_heading_hint": True, "heading_level_hint": level or 2}
+    if boxclass == "list-item":
+        return {"is_list_item": True}
+    if boxclass in ("table", "table-fallback"):
+        return {"is_table_content": True}
+    if boxclass in ("picture", "formula"):
+        return {"is_figure_related": True}
+    if boxclass == "footnote":
+        return {"is_footnote": True}
+    if boxclass in ("page-header", "page-footer"):
+        return {"is_header_footer": True}
+    if boxclass == "caption":
+        hints = {"is_caption": True}
+        if text:
+            _, target = _detect_caption(text)
+            if target is not None:
+                hints["caption_target_type"] = target
+        return hints
+    return {}
+
+
+def _match_toc_level(toc: list, page_no: int, text: str) -> Optional[int]:
+    """Try to match text against TOC entries for the given page to determine heading level."""
+    if not toc or not text:
+        return None
+
+    norm = _normalize_text(text)
+    if not norm:
+        return None
+
+    for entry in toc:
+        if len(entry) < 3:
+            continue
+        level, title, toc_page = entry[0], entry[1], entry[2]
+        if toc_page != page_no:
+            continue
+        toc_norm = _normalize_text(str(title))
+        if not toc_norm:
+            continue
+        if norm.startswith(toc_norm) or toc_norm.startswith(norm):
+            return level
+
+    return None
+
+
+class SentenceBuilder:
+    """Converts ParsedDocument's LayoutBoxes into SentenceUnits."""
+
+    def __init__(self, splitter: str = "default"):
+        self.splitter = splitter
+        self._figure_count = 0
+        if splitter == "multilingual":
+            self._split_re = _SENT_END_MULTI
+        else:
+            self._split_re = _SENT_END_EN
+
+    def build_from_document(self, doc) -> list[SentenceUnit]:
+        """Build SentenceUnits from all pages/boxes in a ParsedDocument."""
+        units = []
+        sent_id = 0
+        prev_unit = None
+        self._figure_count = 0
+
+        for page in doc.pages:
+            list_item_levels = create_list_item_levels(page.boxes)
+            for box_idx, box in enumerate(page.boxes):
+                new_units = self._process_box(
+                    page=page,
+                    box_idx=box_idx,
+                    box=box,
+                    sent_id_start=sent_id,
+                    toc=doc.toc,
+                    prev_unit=prev_unit,
+                    list_item_levels=list_item_levels,
+                )
+                for u in new_units:
+                    units.append(u)
+                    sent_id += 1
+                    prev_unit = u
+
+        # Merge same-page header/footer units that share a y-band
+        units = self._merge_same_page_hf_units(units)
+        units = self._renumber_sent_ids(units)
+
+        for i in range(len(units) - 1):
+            if units[i + 1].line_gap_before is not None and units[i].page_no == units[i + 1].page_no:
+                units[i].line_gap_after = units[i + 1].line_gap_before
+
+        return units
+
+    def _process_box(self, page, box_idx, box, sent_id_start, toc, prev_unit,
+                     list_item_levels=None) -> list[SentenceUnit]:
+        """Process a single LayoutBox into SentenceUnits."""
+        boxclass = box.boxclass
+
+        if boxclass in ("table", "table-fallback"):
+            return self._table_as_unit(page, box_idx, box, sent_id_start, toc)
+
+        if boxclass in ("picture", "formula"):
+            # One document-wide figure number per figure box; it is the "f{n}"
+            # id in the figures view and in text placeholders.
+            self._figure_count += 1
+            if not box.textlines:
+                return self._figure_as_unit(page, box_idx, box, sent_id_start, toc)
+            units = self._split_sentences(page, box_idx, box, sent_id_start, toc,
+                                          prev_unit, list_item_levels)
+            for u in units:
+                u.figure_number = self._figure_count
+            return units
+
+        if box.textlines:
+            return self._split_sentences(page, box_idx, box, sent_id_start, toc,
+                                         prev_unit, list_item_levels)
+
+        return []
+
+    def _table_as_unit(self, page, box_idx, box, sent_id_start, toc) -> list[SentenceUnit]:
+        """Create a single SentenceUnit for a table box."""
+        table_md, table_html = table_content(box)
+        text = box_to_markdown(page, box, box_idx).strip()
+        if not text:
+            return []
+
+        hints = _boxclass_to_hints(box.boxclass, toc, page.page_number, text,
+                                    header_level=getattr(box, 'header_level', None))
+        return [SentenceUnit(
+            sent_id=sent_id_start,
+            text=text,
+            norm_text=_normalize_text(text),
+            page_no=page.page_number,
+            box_index=box_idx,
+            boxclass=box.boxclass,
+            bbox=(box.x0, box.y0, box.x1, box.y1),
+            table_markdown=table_md or None,
+            table_html=table_html,
+            **hints,
+        )]
+
+    def _figure_as_unit(self, page, box_idx, box, sent_id_start, toc) -> list[SentenceUnit]:
+        """Create a single SentenceUnit for a figure/formula without text."""
+        text = figure_placeholder(self._figure_count, box)
+        hints = _boxclass_to_hints(box.boxclass, toc, page.page_number, text,
+                                    header_level=getattr(box, 'header_level', None))
+        image_data = box.image if isinstance(box.image, bytes) else None
+        return [SentenceUnit(
+            sent_id=sent_id_start,
+            text=text,
+            norm_text=_normalize_text(text),
+            page_no=page.page_number,
+            box_index=box_idx,
+            boxclass=box.boxclass,
+            bbox=(box.x0, box.y0, box.x1, box.y1),
+            figure_number=self._figure_count,
+            image_data=image_data,
+            **hints,
+        )]
+
+    def _split_sentences(self, page, box_idx, box, sent_id_start, toc, prev_unit,
+                         list_item_levels=None) -> list[SentenceUnit]:
+        """Split a box's rendered markdown into sentence-level SentenceUnits."""
+        textlines = box.textlines
+        if not textlines:
+            return []
+
+        # Canonical text: the same markdown to_markdown emits for this box.
+        # The renderers join spans with proper spacing and resolve hyphenation,
+        # so no line-break collapsing is needed here.
+        joined = box_to_markdown(page, box, box_idx, list_item_levels).strip()
+        if not joined:
+            return []
+
+        font_size, font_flags = _get_dominant_font(textlines)
+        first_gap = None
+        if prev_unit and prev_unit.page_no == page.page_number:
+            if textlines[0].get("bbox") is not None:
+                first_gap = float(textlines[0]["bbox"][1]) - prev_unit.bbox[3]
+
+        # Match patterns against text without markdown decoration
+        plain = _strip_md_decoration(joined)
+        hints = _boxclass_to_hints(box.boxclass, toc, page.page_number, plain,
+                                    header_level=getattr(box, 'header_level', None))
+
+        # Detect captions in non-caption boxclass text boxes
+        if not hints.get("is_caption") and box.boxclass not in (
+            "title", "section-header", "table", "table-fallback",
+            "picture", "formula", "footnote", "page-header", "page-footer",
+        ):
+            is_cap, cap_target = _detect_caption(plain)
+            if is_cap:
+                hints["is_caption"] = True
+                hints["caption_target_type"] = cap_target
+
+        # Check if this should be kept as a single unit (no sentence splitting).
+        # Multi-block markdown (code blocks, multi-item lists, multi-note
+        # footnotes) contains newlines and must never be sentence-split.
+        keep_single = (
+            hints.get("is_heading_hint") or hints.get("is_footnote")
+            or hints.get("is_header_footer") or hints.get("is_caption")
+            or hints.get("is_list_item")
+            or "\n" in joined
+        )
+
+        if not keep_single:
+            sentences = self._split_re.split(joined)
+            sentences = [s.strip() for s in sentences if s.strip()]
+            if not sentences:
+                return []
+            keep_single = len(sentences) == 1
+
+        if keep_single:
+            bbox = _compute_bbox_union(textlines)
+            return [SentenceUnit(
+                sent_id=sent_id_start,
+                text=joined,
+                norm_text=_normalize_text(joined),
+                page_no=page.page_number,
+                box_index=box_idx,
+                boxclass=box.boxclass,
+                bbox=bbox,
+                font_size_dominant=font_size,
+                font_flags_dominant=font_flags,
+                line_gap_before=first_gap,
+                **hints,
+            )]
+
+        box_bbox = _compute_bbox_union(textlines)
+        units = []
+        for i, sent_text in enumerate(sentences):
+            units.append(SentenceUnit(
+                sent_id=sent_id_start + i,
+                text=sent_text,
+                norm_text=_normalize_text(sent_text),
+                page_no=page.page_number,
+                box_index=box_idx,
+                boxclass=box.boxclass,
+                bbox=box_bbox,  # approximate: use whole box bbox
+                font_size_dominant=font_size,
+                font_flags_dominant=font_flags,
+                line_gap_before=first_gap if i == 0 else None,
+                **hints,
+            ))
+
+        return units
+
+    def detect_repeated_headers_footers(self, doc) -> set[tuple[int, int]]:
+        """Detect header/footer boxes that repeat across pages.
+
+        Returns set of (page_no, box_index) tuples to exclude.
+        """
+        if not doc.pages or len(doc.pages) < 3:
+            return set()
+
+        hf_texts = defaultdict(list)  # (boxclass, y_bucket, text_norm) -> [(page_no, box_idx)]
+
+        for page in doc.pages:
+            for box_idx, box in enumerate(page.boxes):
+                if box.boxclass in ("page-header", "page-footer") and box.textlines:
+                    text = _normalize_text(box_to_markdown(page, box, box_idx))
+                    if text:
+                        y_bucket = round(box.y0 / 10) * 10  # bucket by ~10pt
+                        hf_texts[(box.boxclass, y_bucket, text)].append((page.page_number, box_idx))
+
+        threshold = max(2, len(doc.pages) * 0.5)
+        repeated = set()
+
+        for _key, locations in hf_texts.items():
+            if len(locations) >= threshold:
+                repeated.update(locations)
+
+        return repeated
+
+    # ── Header/Footer same-line merge ─────────────────────────────────
+
+    def _merge_same_page_hf_units(self, units: list[SentenceUnit],
+                                   y_tolerance: float = 20.0) -> list[SentenceUnit]:
+        """Merge consecutive same-page, same-boxclass HF units sharing a y-band."""
+        if not units:
+            return units
+
+        result = []
+        i = 0
+        while i < len(units):
+            u = units[i]
+            if not u.is_header_footer:
+                result.append(u)
+                i += 1
+                continue
+
+            # Collect consecutive HF units on the same page with the same boxclass
+            group = [u]
+            j = i + 1
+            while j < len(units):
+                nxt = units[j]
+                if (nxt.is_header_footer
+                        and nxt.page_no == u.page_no
+                        and nxt.boxclass == u.boxclass):
+                    group.append(nxt)
+                    j += 1
+                else:
+                    break
+
+            if len(group) == 1:
+                result.append(u)
+            else:
+                # Group by y-band and merge each band
+                bands = self._group_by_y_band(group, y_tolerance)
+                for band in bands:
+                    result.append(self._merge_hf_group(band))
+            i = j
+
+        return result
+
+    @staticmethod
+    def _group_by_y_band(units: list[SentenceUnit],
+                         y_tolerance: float) -> list[list[SentenceUnit]]:
+        """Group units by y-center proximity (greedy clustering)."""
+        sorted_units = sorted(units, key=lambda u: (u.bbox[1] + u.bbox[3]) / 2)
+        bands: list[list[SentenceUnit]] = []
+        for u in sorted_units:
+            yc = (u.bbox[1] + u.bbox[3]) / 2
+            if bands:
+                last_yc = (bands[-1][-1].bbox[1] + bands[-1][-1].bbox[3]) / 2
+                if abs(yc - last_yc) <= y_tolerance:
+                    bands[-1].append(u)
+                    continue
+            bands.append([u])
+        return bands
+
+    @staticmethod
+    def _merge_hf_group(group: list[SentenceUnit]) -> SentenceUnit:
+        """Merge a group of HF units into a single unit (left-to-right order)."""
+        if len(group) == 1:
+            return group[0]
+
+        sorted_group = sorted(group, key=lambda u: u.bbox[0])  # sort by x0
+        text = " | ".join(u.text for u in sorted_group)
+
+        bbox = union_bbox(u.bbox for u in sorted_group)
+
+        # Use font info from the longest-text unit
+        longest = max(sorted_group, key=lambda u: len(u.text))
+
+        # Collect all source box indices
+        source_indices = []
+        for u in sorted_group:
+            source_indices.append(u.box_index)
+            source_indices.extend(u._source_box_indices)
+
+        merged = SentenceUnit(
+            sent_id=sorted_group[0].sent_id,
+            text=text,
+            norm_text=_normalize_text(text),
+            page_no=sorted_group[0].page_no,
+            box_index=sorted_group[0].box_index,
+            boxclass=sorted_group[0].boxclass,
+            bbox=bbox,
+            font_size_dominant=longest.font_size_dominant,
+            font_flags_dominant=longest.font_flags_dominant,
+            line_gap_before=sorted_group[0].line_gap_before,
+            is_header_footer=True,
+        )
+        merged._source_box_indices = source_indices
+        return merged
+
+    @staticmethod
+    def _renumber_sent_ids(units: list[SentenceUnit]) -> list[SentenceUnit]:
+        """Renumber sent_ids sequentially from 0."""
+        for i, u in enumerate(units):
+            u.sent_id = i
+        return units

--- a/src/helpers/chunking/sentence_builder.py
+++ b/src/helpers/chunking/sentence_builder.py
@@ -12,20 +12,51 @@ from .text_source import (
     table_content,
 )
 
-# Sentence-ending patterns
+# Sentence-ending patterns.
+#
+# The match covers the sentence-ending punctuation *and* any closing
+# quotes/brackets, so those stay with the sentence they close; group 1 is
+# the boundary whitespace and is the only span a split removes (see
+# _split_sentence_text).  Splitting therefore never drops a non-whitespace
+# character of the rendered markdown, which the chunk-text contract
+# requires (chunk text == to_markdown rendering, up to whitespace).
 _SENT_END_EN = re.compile(
-    r'(?<=[.!?])'        # after sentence-ending punctuation
-    r'(?:\s*["\'\)\]]*)'  # optional closing quotes/brackets
-    r'\s+'                # followed by whitespace
+    r'[.!?]'              # sentence-ending punctuation
+    r'\s*["\'\)\]]*'      # optional closing quotes/brackets
+    r'(\s+)'              # boundary whitespace (the only removed span)
     r'(?=[A-Z"\'\(\[])'   # before uppercase or opening quote/bracket
 )
 
 _SENT_END_MULTI = re.compile(
-    r'(?<=[.!?。！？])'
-    r'(?:\s*["\'\)\]」』]*)'
-    r'\s*'
+    r'[.!?。！？]'
+    r'\s*["\'\)\]」』]*'
+    r'(\s*)'
     r'(?=[A-Z가-힣ㄱ-ㅎㅏ-ㅣ一-鿿"\'\(\[「『]|$)'
 )
+
+
+def _split_sentence_text(text: str, pattern) -> list[str]:
+    """Split *text* into sentences at *pattern*, losing only whitespace.
+
+    ``pattern`` matches a sentence end and marks the boundary whitespace as
+    group 1; everything else the match consumed (the punctuation and any
+    closing quote/bracket) stays with the preceding sentence.  Re-joining
+    the returned pieces reproduces *text* up to whitespace.
+
+    ``re.split`` cannot be used for this: it discards the whole match, which
+    is what dropped closing quotes and brackets from chunk text.
+    """
+    pieces = []
+    pos = 0
+    for m in pattern.finditer(text):
+        piece = text[pos:m.start(1)].strip()
+        if piece:
+            pieces.append(piece)
+        pos = m.end(1)
+    tail = text[pos:].strip()
+    if tail:
+        pieces.append(tail)
+    return pieces
 
 # Whitespace normalization
 _MULTI_SPACE = re.compile(r'[ \t]+')
@@ -329,8 +360,7 @@ class SentenceBuilder:
         )
 
         if not keep_single:
-            sentences = self._split_re.split(joined)
-            sentences = [s.strip() for s in sentences if s.strip()]
+            sentences = _split_sentence_text(joined, self._split_re)
             if not sentences:
                 return []
             keep_single = len(sentences) == 1

--- a/src/helpers/chunking/serializer.py
+++ b/src/helpers/chunking/serializer.py
@@ -1,0 +1,288 @@
+"""Step E: Serialize ProtoChunks into Chunks, plus table/figure/section views.
+
+The serializer materializes chunk text once (assembly never joins text),
+builds the tables/figures/sections views with bidirectional links
+(chunk.metadata.table_ids/figure_ids/section_id <-> view.chunk_id(s)),
+and attaches citation metadata (section_path, pages, element ids).
+
+section_path derives from the layout-detected heading structure — it is
+the innermost owning section's path (D18). It never consults the PDF TOC,
+so it stays populated and consistent with the sections view on documents
+without bookmarks.
+"""
+
+import re
+
+from .models import (
+    Chunk,
+    ChunkMetadata,
+    FigureChunk,
+    ProtoChunk,
+    SectionChunk,
+    TableChunk,
+    element_id,
+)
+from .text_source import extract_table_headers
+
+# Markdown decoration around section titles (both ends: "# **Title**")
+_MD_DECOR_RE = re.compile(r'^[#>*_`\s]+')
+_MD_DECOR_TRAIL_RE = re.compile(r'[*_`\s]+$')
+
+
+class ChunkSerializer:
+    """Converts ProtoChunks into Chunks and builds the document views."""
+
+    def __init__(self, doc):
+        self.doc = doc
+        self._ocr_pages = {
+            p.page_number for p in doc.pages if getattr(p, "full_ocred", False)
+        }
+
+    def serialize(self, proto_chunks: list[ProtoChunk]):
+        """Convert ProtoChunks to Chunks.
+
+        Returns (chunks, tables, figures, sections) where tables/figures/
+        sections are the document views, bidirectionally linked to chunks.
+        """
+        if not proto_chunks:
+            return [], [], [], []
+
+        chunks = [self._make_chunk(pc) for pc in proto_chunks]
+        tables, figures, sections = self._build_views(proto_chunks, chunks)
+
+        # section_path is known only after the views pass assigned each
+        # chunk its innermost section, so contextual text renders last.
+        for pc, chunk in zip(proto_chunks, chunks):
+            chunk.contextual_text = self._build_contextual_text(
+                pc, chunk.metadata.section_path)
+
+        return chunks, tables, figures, sections
+
+    def _make_chunk(self, pc: ProtoChunk) -> Chunk:
+        """Create a Chunk from a ProtoChunk (text materialized here, once)."""
+        pc.text = "\n".join(s.text for s in pc._sentences)
+
+        metadata = ChunkMetadata(
+            page_start=pc.page_start,
+            page_end=pc.page_end,
+            element_ids=[element_id(p, b) for p, b in pc.box_indices],
+            chunk_type=pc.chunk_type_hint or "paragraph",
+            chunk_types=pc.chunk_types or [pc.chunk_type_hint or "paragraph"],
+            token_count=pc.token_count,
+            bboxes=pc.bboxes,
+            lists=_group_list_items(pc._sentences),
+            ocr=any(p in self._ocr_pages
+                    for p in range(pc.page_start, pc.page_end + 1)),
+            file_path=self.doc.filename,
+            page_count=self.doc.page_count,
+        )
+
+        return Chunk(
+            id=f"c{pc.chunk_id}",
+            text=pc.text,
+            contextual_text="",   # rendered in serialize() after views
+            metadata=metadata,
+        )
+
+    # ── Views (tables / figures / sections) ─────────────────────────
+
+    def _build_views(self, proto_chunks, chunks):
+        """Build t/f/s views with bidirectional chunk links."""
+        tables = []
+        figures = []
+        sections = []
+        seen_figures = {}       # figure_number -> FigureChunk
+        open_sections = []      # stack of (level, SectionChunk)
+
+        # Global element index per (page, box) address, for element_span.
+        box_offset = {}
+        total_boxes = 0
+        for page in self.doc.pages:
+            box_offset[page.page_number] = total_boxes
+            total_boxes += len(page.boxes)
+
+        def _link(section, chunk):
+            if chunk.id not in section.child_chunk_ids:
+                section.child_chunk_ids.append(chunk.id)
+                section.token_count += chunk.metadata.token_count
+
+        for pc, chunk in zip(proto_chunks, chunks):
+            for idx, s in enumerate(pc._sentences):
+                if s.is_table_content:
+                    cap = _nearest_caption(pc._sentences, idx, "table")
+                    table = TableChunk(
+                        id=f"t{len(tables)}",
+                        chunk_id=chunk.id,
+                        element_id=element_id(s.page_no, s.box_index),
+                        page=s.page_no,
+                        bbox=s.bbox,
+                        markdown=s.table_markdown,
+                        html=s.table_html,
+                        headers=extract_table_headers(s.table_html),
+                        caption=cap.text if cap else None,
+                        caption_element_id=(
+                            element_id(cap.page_no, cap.box_index) if cap else None),
+                        token_count=s.token_count,
+                    )
+                    tables.append(table)
+                    chunk.metadata.table_ids.append(table.id)
+
+                elif s.is_figure_related and s.figure_number is not None:
+                    fig = seen_figures.get(s.figure_number)
+                    if fig is None:
+                        placeholder = s.text if s.text.startswith("[Figure") else ""
+                        cap = _nearest_caption(pc._sentences, idx, "figure")
+                        fig = FigureChunk(
+                            id=f"f{s.figure_number}",
+                            chunk_id=chunk.id,
+                            element_id=element_id(s.page_no, s.box_index),
+                            page=s.page_no,
+                            bbox=s.bbox,
+                            boxclass=s.boxclass,
+                            ocr_text=None if placeholder else s.text,
+                            placeholder=placeholder,
+                            caption=cap.text if cap else None,
+                            caption_element_id=(
+                                element_id(cap.page_no, cap.box_index) if cap else None),
+                            image=s.image_data,
+                        )
+                        seen_figures[s.figure_number] = fig
+                        figures.append(fig)
+                        chunk.metadata.figure_ids.append(fig.id)
+                    else:
+                        # further sentences of the same figure box
+                        if not s.text.startswith("[Figure"):
+                            fig.ocr_text = ((fig.ocr_text + "\n" + s.text).strip()
+                                            if fig.ocr_text else s.text)
+
+                elif s.is_heading_hint:
+                    level = s.heading_level_hint or 1
+                    while open_sections and open_sections[-1][0] >= level:
+                        open_sections.pop()
+                    title = _MD_DECOR_TRAIL_RE.sub(
+                        "", _MD_DECOR_RE.sub("", s.text)).strip()
+                    section = SectionChunk(
+                        id=f"s{len(sections)}",
+                        title=title,
+                        level=level,
+                        page_start=s.page_no,
+                        page_end=s.page_no,
+                        heading_element_id=element_id(s.page_no, s.box_index),
+                        path=[sec.title for _l, sec in open_sections] + [title],
+                        element_span=(
+                            box_offset.get(s.page_no, 0) + s.box_index,
+                            total_boxes,
+                        ),
+                    )
+                    sections.append(section)
+                    # the chunk carrying the heading belongs to the section,
+                    # even if the section closes within this same chunk
+                    _link(section, chunk)
+                    open_sections.append((level, section))
+
+            # every open section contains this chunk; innermost wins the link
+            for _level, section in open_sections:
+                _link(section, chunk)
+                section.page_end = max(section.page_end, pc.page_end)
+            if open_sections:
+                innermost = open_sections[-1][1]
+                chunk.metadata.section_id = innermost.id
+                chunk.metadata.section_path = list(innermost.path)
+
+        # Close element spans: a section runs until the next heading at the
+        # same or a shallower level (else to the end of the document).
+        for i, sec in enumerate(sections):
+            end = total_boxes
+            for later in sections[i + 1:]:
+                if later.level <= sec.level:
+                    end = later.element_span[0]
+                    break
+            sec.element_span = (sec.element_span[0], end)
+
+        # Tables/figures inherit the section of their owning chunk.
+        chunk_by_id = {c.id: c for c in chunks}
+        for view in (tables, figures):
+            for item in view:
+                owner = chunk_by_id.get(item.chunk_id)
+                if owner is not None:
+                    item.section_id = owner.metadata.section_id
+
+        return tables, figures, sections
+
+    # ── Contextual text ─────────────────────────────────────────────
+
+    def _build_contextual_text(self, pc: ProtoChunk, hierarchy: list[str]) -> str:
+        """Build context-enriched text for embedding."""
+        parts = []
+
+        if hierarchy:
+            parts.append(f"[Section] {' > '.join(hierarchy)}")
+
+        if pc.page_start == pc.page_end:
+            parts.append(f"[Page] {pc.page_start}")
+        else:
+            parts.append(f"[Pages] {pc.page_start}-{pc.page_end}")
+
+        non_para = [t for t in (pc.chunk_types or []) if t != "paragraph"]
+        if non_para:
+            parts.append(f"[Type] {', '.join(non_para)}")
+
+        parts.append(f"[Content]\n{pc.text}")
+
+        return "\n".join(parts)
+
+
+# ── Module-level helpers ────────────────────────────────────────────
+
+def _nearest_caption(sents, idx, target_type):
+    """Nearest caption unit to sents[idx] targeting *target_type* (or untyped)."""
+    best = None
+    best_dist = None
+    for j, s in enumerate(sents):
+        if not s.is_caption:
+            continue
+        if s.caption_target_type not in (None, target_type):
+            continue
+        dist = abs(j - idx)
+        if best_dist is None or dist < best_dist:
+            best, best_dist = s, dist
+    return best
+
+
+def _group_list_items(sents) -> list[dict]:
+    """Group consecutive list-item sentences into logical list groups.
+
+    Each group gets a union bbox and an ordered items list.
+    Non-list sentences break the current group, so two separate
+    runs of list-items produce two distinct list groups.
+
+    Returns: [{"items": [{"text": str, "bbox": tuple}], "bbox": (page, x0, y0, x1, y1)}]
+    """
+    groups = []
+    current_items = []
+
+    for s in sents:
+        if s.is_list_item:
+            current_items.append(s)
+        else:
+            if current_items:
+                groups.append(_finalize_list_group(current_items))
+                current_items = []
+
+    if current_items:
+        groups.append(_finalize_list_group(current_items))
+
+    return groups
+
+
+def _finalize_list_group(items) -> dict:
+    """Build a list group dict from consecutive list-item sentences."""
+    entries = [{"text": s.text, "bbox": s.bbox} for s in items]
+    # Union bbox with page (use first item's page)
+    page = items[0].page_no
+    x0 = min(s.bbox[0] for s in items)
+    y0 = min(s.bbox[1] for s in items)
+    x1 = max(s.bbox[2] for s in items)
+    y1 = max(s.bbox[3] for s in items)
+    return {"items": entries, "bbox": (page, x0, y0, x1, y1)}
+

--- a/src/helpers/chunking/serializer.py
+++ b/src/helpers/chunking/serializer.py
@@ -53,7 +53,7 @@ class ChunkSerializer:
         # section_path is known only after the views pass assigned each
         # chunk its innermost section, so contextual text renders last.
         for pc, chunk in zip(proto_chunks, chunks):
-            chunk.contextual_text = self._build_contextual_text(
+            chunk.tagged_content = self._build_tagged_content(
                 pc, chunk.metadata.section_path)
 
         return chunks, tables, figures, sections
@@ -66,7 +66,7 @@ class ChunkSerializer:
             page_start=pc.page_start,
             page_end=pc.page_end,
             element_ids=[element_id(p, b) for p, b in pc.box_indices],
-            types=pc.types or [pc.chunk_type_hint or "paragraph"],
+            types=pc.types or [pc.primary_type or "paragraph"],
             token_count=pc.token_count,
             bboxes=pc.bboxes,
             lists=_group_list_items(pc._sentences),
@@ -79,7 +79,7 @@ class ChunkSerializer:
         return Chunk(
             id=f"c{pc.chunk_id}",
             text=pc.text,
-            contextual_text="",   # rendered in serialize() after views
+            tagged_content="",   # rendered in serialize() after views
             metadata=metadata,
         )
 
@@ -210,7 +210,7 @@ class ChunkSerializer:
 
     # ── Contextual text ─────────────────────────────────────────────
 
-    def _build_contextual_text(self, pc: ProtoChunk, hierarchy: list[str]) -> str:
+    def _build_tagged_content(self, pc: ProtoChunk, hierarchy: list[str]) -> str:
         """Build context-enriched text for embedding."""
         parts = []
 
@@ -226,7 +226,7 @@ class ChunkSerializer:
         if non_para:
             parts.append(f"[Type] {', '.join(non_para)}")
 
-        parts.append(f"[Content]\n{pc.text}")
+        parts.append(f"[Markdown]\n{pc.text}")
 
         return "\n".join(parts)
 

--- a/src/helpers/chunking/serializer.py
+++ b/src/helpers/chunking/serializer.py
@@ -66,8 +66,7 @@ class ChunkSerializer:
             page_start=pc.page_start,
             page_end=pc.page_end,
             element_ids=[element_id(p, b) for p, b in pc.box_indices],
-            chunk_type=pc.chunk_type_hint or "paragraph",
-            chunk_types=pc.chunk_types or [pc.chunk_type_hint or "paragraph"],
+            types=pc.types or [pc.chunk_type_hint or "paragraph"],
             token_count=pc.token_count,
             bboxes=pc.bboxes,
             lists=_group_list_items(pc._sentences),
@@ -223,7 +222,7 @@ class ChunkSerializer:
         else:
             parts.append(f"[Pages] {pc.page_start}-{pc.page_end}")
 
-        non_para = [t for t in (pc.chunk_types or []) if t != "paragraph"]
+        non_para = [t for t in (pc.types or []) if t != "paragraph"]
         if non_para:
             parts.append(f"[Type] {', '.join(non_para)}")
 

--- a/src/helpers/chunking/serializer.py
+++ b/src/helpers/chunking/serializer.py
@@ -22,7 +22,7 @@ from .models import (
     TableChunk,
     element_id,
 )
-from .text_source import extract_table_headers
+from .text_source import extract_table_headers, table_content
 
 # Markdown decoration around section titles (both ends: "# **Title**")
 _MD_DECOR_RE = re.compile(r'^[#>*_`\s]+')
@@ -70,8 +70,10 @@ class ChunkSerializer:
             token_count=pc.token_count,
             bboxes=pc.bboxes,
             lists=_group_list_items(pc._sentences),
-            ocr=any(p in self._ocr_pages
-                    for p in range(pc.page_start, pc.page_end + 1)),
+            # Pages that actually contributed units — not the page span: a
+            # chunk bridging pages 1 and 3 must not inherit page 2's OCR
+            # flag when page 2 put nothing in it.
+            ocr=any(s.page_no in self._ocr_pages for s in pc._sentences),
             file_path=self.doc.filename,
             page_count=self.doc.page_count,
         )
@@ -153,6 +155,11 @@ class ChunkSerializer:
                         if not s.text.startswith("[Figure"):
                             fig.ocr_text = ((fig.ocr_text + "\n" + s.text).strip()
                                             if fig.ocr_text else s.text)
+                        # A figure's text can be split across chunks; every
+                        # chunk holding part of it links back to it, while
+                        # FigureChunk.chunk_id keeps naming the first one.
+                        if fig.id not in chunk.metadata.figure_ids:
+                            chunk.metadata.figure_ids.append(fig.id)
 
                 elif s.is_heading_hint:
                     level = s.heading_level_hint or 1
@@ -198,6 +205,13 @@ class ChunkSerializer:
                     break
             sec.element_span = (sec.element_span[0], end)
 
+        # Table boxes whose rendering was empty produced no unit and would
+        # otherwise be missing from the view and from the diagnostics that
+        # are supposed to report them.
+        unchunked = self._unchunked_tables(proto_chunks)
+        if unchunked:
+            tables = _merge_unchunked_tables(tables, unchunked, chunks)
+
         # Tables/figures inherit the section of their owning chunk.
         chunk_by_id = {c.id: c for c in chunks}
         for view in (tables, figures):
@@ -207,6 +221,42 @@ class ChunkSerializer:
                     item.section_id = owner.metadata.section_id
 
         return tables, figures, sections
+
+    def _unchunked_tables(self, proto_chunks) -> list:
+        """Table boxes that produced no unit, as chunk-less TableChunks.
+
+        A table box whose rendering is empty yields no SentenceUnit, so no
+        chunk carries it. It stays in the element registry, but without
+        this it would also disappear from ``tables`` and therefore from
+        ``diagnostics["degenerate_tables"]`` — exactly the case the
+        diagnostic exists to surface. Such a table is exposed with
+        ``chunk_id=None``: it is addressable and reported, and its empty
+        rendering is visible in ``TableChunk.text``.
+        """
+        chunked = {(s.page_no, s.box_index)
+                   for pc in proto_chunks for s in pc._sentences
+                   if s.is_table_content}
+        missing = []
+        for page in self.doc.pages:
+            for box_idx, box in enumerate(page.boxes):
+                if box.boxclass not in ("table", "table-fallback"):
+                    continue
+                if (page.page_number, box_idx) in chunked:
+                    continue
+                markdown, html = table_content(box)
+                if markdown is None and html is None:
+                    markdown = ""       # nothing rendered at all
+                missing.append(TableChunk(
+                    id="",              # numbered in reading order below
+                    chunk_id=None,
+                    element_id=element_id(page.page_number, box_idx),
+                    page=page.page_number,
+                    bbox=(box.x0, box.y0, box.x1, box.y1),
+                    markdown=markdown,
+                    html=html,
+                    headers=extract_table_headers(html),
+                ))
+        return missing
 
     # ── Contextual text ─────────────────────────────────────────────
 
@@ -233,6 +283,32 @@ class ChunkSerializer:
 
 # ── Module-level helpers ────────────────────────────────────────────
 
+def _table_address(table) -> tuple:
+    """(page, box) reading-order key from a TableChunk's element id."""
+    return (table.page, int(table.element_id.rsplit(".b", 1)[-1]))
+
+
+def _merge_unchunked_tables(tables, unchunked, chunks) -> list:
+    """Insert chunk-less tables into the view, keeping ids in reading order.
+
+    Ids are re-issued over the merged, reading-ordered list and the chunk
+    back-links (``metadata.table_ids``) are rebuilt from it, so ``t{n}``
+    still numbers tables the way the document reads.
+    """
+    merged = sorted(list(tables) + list(unchunked), key=_table_address)
+    for i, table in enumerate(merged):
+        table.id = f"t{i}"
+
+    by_id = {c.id: c for c in chunks}
+    for chunk in chunks:
+        chunk.metadata.table_ids.clear()
+    for table in merged:
+        owner = by_id.get(table.chunk_id) if table.chunk_id else None
+        if owner is not None:
+            owner.metadata.table_ids.append(table.id)
+    return merged
+
+
 def _nearest_caption(sents, idx, target_type):
     """Nearest caption unit to sents[idx] targeting *target_type* (or untyped)."""
     best = None
@@ -251,11 +327,19 @@ def _nearest_caption(sents, idx, target_type):
 def _group_list_items(sents) -> list[dict]:
     """Group consecutive list-item sentences into logical list groups.
 
-    Each group gets a union bbox and an ordered items list.
+    Each group gets one union bbox *per page* and an ordered items list.
     Non-list sentences break the current group, so two separate
     runs of list-items produce two distinct list groups.
 
-    Returns: [{"items": [{"text": str, "bbox": tuple}], "bbox": (page, x0, y0, x1, y1)}]
+    Returns::
+
+        [{"items":  [{"text": str, "page": int, "bbox": (x0, y0, x1, y1)}],
+          "bboxes": [(page, x0, y0, x1, y1), ...]}]
+
+    A list continuing across a page break yields one entry in ``bboxes``
+    per page, in page order — unioning across pages would place the whole
+    group in a rectangle that exists on neither page. Item bboxes stay
+    4-tuples and carry their page next to them, matching ``Element.bbox``.
     """
     groups = []
     current_items = []
@@ -276,12 +360,22 @@ def _group_list_items(sents) -> list[dict]:
 
 def _finalize_list_group(items) -> dict:
     """Build a list group dict from consecutive list-item sentences."""
-    entries = [{"text": s.text, "bbox": s.bbox} for s in items]
-    # Union bbox with page (use first item's page)
-    page = items[0].page_no
-    x0 = min(s.bbox[0] for s in items)
-    y0 = min(s.bbox[1] for s in items)
-    x1 = max(s.bbox[2] for s in items)
-    y1 = max(s.bbox[3] for s in items)
-    return {"items": entries, "bbox": (page, x0, y0, x1, y1)}
+    entries = [{"text": s.text, "page": s.page_no, "bbox": s.bbox}
+               for s in items]
+
+    by_page = {}
+    for s in items:
+        by_page.setdefault(s.page_no, []).append(s.bbox)
+
+    bboxes = []
+    for page_no in sorted(by_page):
+        page_boxes = by_page[page_no]
+        bboxes.append((
+            page_no,
+            min(b[0] for b in page_boxes),
+            min(b[1] for b in page_boxes),
+            max(b[2] for b in page_boxes),
+            max(b[3] for b in page_boxes),
+        ))
+    return {"items": entries, "bboxes": bboxes}
 

--- a/src/helpers/chunking/text_source.py
+++ b/src/helpers/chunking/text_source.py
@@ -1,0 +1,180 @@
+"""Canonical text source for chunking: render one LayoutBox to markdown.
+
+This module is the single place where the chunking package calls the
+markdown renderers in ``document_layout``.  ``box_to_markdown`` mirrors the
+per-box dispatch of ``ParsedDocument.to_markdown`` so that chunk text is the
+same markdown the document renderer emits for that box — upstream renderer
+signature drift is absorbed here and nowhere else.
+
+Documented deviations from ``to_markdown``:
+
+- picture/formula boxes without text are not rendered here at all; the
+  chunker represents them with a placeholder (see ``figure_placeholder``).
+- formula boxes *with* textlines are rendered via ``text_to_md``.
+  ``to_markdown`` drops that text (it only emits the image reference), but
+  dropping it from chunks would lose indexable content.
+- image files / base64 payloads are never inlined into chunk text; images
+  travel in metadata.
+"""
+
+from ..document_layout import (
+    create_list_item_levels,
+    footnote_to_md,
+    list_item_to_md,
+    picture_text_to_md,
+    section_hdr_to_md,
+    text_to_md,
+    title_to_md,
+)
+
+__all__ = [
+    "box_to_markdown",
+    "create_list_item_levels",
+    "extract_table_headers",
+    "figure_placeholder",
+    "table_content",
+]
+
+
+def table_content(box):
+    """Adapter for ``box.table`` — the only place chunking reads its schema.
+
+    Returns ``(markdown, html)`` where at most one side is a string,
+    mirroring the ``to_markdown`` branching: when the parse ran with HTML
+    table rendering, the table dict carries the canonical rendering under
+    ``"html"`` and ``markdown`` is ``None``; otherwise ``markdown`` is the
+    canonical rendering (possibly ``""`` for a degenerate table) and
+    ``html`` is ``None``.
+
+    Routing uses ``is not None`` on purpose: a degenerate table carries
+    ``markdown == ""`` and must still route as markdown, never as html.
+    """
+    table = box.table if isinstance(box.table, dict) else {}
+    html = table.get("html")
+    if html is None:
+        # Defensive: accept per-table entries even if the aggregate "html"
+        # key is absent (D13 — header info lives in these renderings).
+        per_table = table.get("html_tables")
+        if per_table:
+            html = "\n\n".join(
+                t.get("html", "") for t in per_table if isinstance(t, dict)
+            ) or None
+    if html is not None:
+        return None, html
+    return table.get("markdown"), None
+
+
+def extract_table_headers(html):
+    """Header cell texts from a table's HTML rendering (D13).
+
+    Header identity comes exclusively from ``<th>`` elements emitted by the
+    table engine — no local header heuristics.  Returns ``[]`` when the
+    rendering carries no ``<th>`` (including all markdown-mode parses).
+    """
+    if not html:
+        return []
+
+    from html.parser import HTMLParser
+
+    class _THCollector(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self._depth = 0
+            self._parts = []
+            self.headers = []
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "th":
+                self._depth += 1
+                self._parts = []
+
+        def handle_endtag(self, tag):
+            if tag == "th" and self._depth:
+                self._depth -= 1
+                self.headers.append("".join(self._parts).strip())
+
+        def handle_data(self, data):
+            if self._depth:
+                self._parts.append(data)
+
+    collector = _THCollector()
+    collector.feed(html)
+    return collector.headers
+
+
+def _copy_textlines(textlines):
+    """Copy textlines deep enough to isolate renderer side effects.
+
+    Some renderers mutate their input in place (``footnote_to_md`` extends
+    the first line's span list, ``list_item_to_md`` rewrites/pops spans), so
+    rendering the same box twice — e.g. ``to_chunks`` followed by
+    ``to_markdown`` — would duplicate text.  Rendering from a copy keeps
+    ``box_to_markdown`` free of side effects on the parsed document.
+    """
+    return [
+        {**tl, "spans": [dict(s) for s in tl.get("spans", [])]}
+        for tl in textlines
+    ]
+
+
+def figure_placeholder(fig_number, box):
+    """Stable text placeholder for a figure/formula box without text."""
+    w, h = int(box.x1 - box.x0), int(box.y1 - box.y0)
+    return f"[Figure f{fig_number}: {w}x{h}]"
+
+
+def box_to_markdown(page, box, box_idx, list_item_levels=None, ignore_code=False):
+    """Render one LayoutBox to markdown, mirroring ``to_markdown`` dispatch.
+
+    Args:
+        page: the PageLayout owning the box (``full_ocred`` is honored).
+        box: the LayoutBox to render.
+        box_idx: index of the box on its page (list-item level lookup).
+        list_item_levels: optional precomputed ``create_list_item_levels``
+            result for the page; computed on demand when omitted.
+        ignore_code: suppress code-block styling (as in ``to_markdown``).
+
+    Returns the markdown string for the box ("" when there is nothing to
+    render).  Trailing block separators ("\\n\\n") are preserved as emitted
+    by the renderers; callers strip as needed.
+    """
+    btype = box.boxclass
+    ignore_code = ignore_code or page.full_ocred
+
+    if btype in ("table", "table-fallback"):
+        markdown, html = table_content(box)
+        if html is not None:
+            return html
+        table_text = markdown or ""
+        if page.full_ocred:
+            # remove code style if page was OCR'd
+            table_text = table_text.replace("`", "")
+        if table_text.strip():
+            return table_text
+        # degenerate/legacy table without a rendering: fall back to its text
+        textlines = getattr(box, "textlines", None)
+        if textlines:
+            return text_to_md(_copy_textlines(textlines), ignore_code=ignore_code)
+        return ""
+
+    textlines = getattr(box, "textlines", None)
+    if not textlines:
+        return ""
+    textlines = _copy_textlines(textlines)
+
+    if btype == "picture":
+        return picture_text_to_md(textlines, ignore_code=ignore_code)
+    if btype == "formula":
+        # to_markdown drops formula text; keep it (documented deviation)
+        return text_to_md(textlines, ignore_code=ignore_code)
+    if btype == "title":
+        return title_to_md(box.header_level, textlines)
+    if btype == "section-header":
+        return section_hdr_to_md(box.header_level, textlines)
+    if btype == "list-item":
+        if list_item_levels is None:
+            list_item_levels = create_list_item_levels(page.boxes)
+        return list_item_to_md(textlines, list_item_levels.get(box_idx, 1))
+    if btype == "footnote":
+        return footnote_to_md(textlines)
+    return text_to_md(textlines, ignore_code=ignore_code)

--- a/src/helpers/chunking/token_utils.py
+++ b/src/helpers/chunking/token_utils.py
@@ -1,0 +1,46 @@
+"""Token counting utilities for chunk size management."""
+
+from typing import Callable, Optional
+
+# Approximate tokens per character ratio for fallback estimation
+_CHARS_PER_TOKEN_APPROX = 4.0
+
+
+class TokenCounter:
+    """Counts tokens using tiktoken or a custom function.
+
+    Falls back to character-based estimation if tiktoken is unavailable.
+    """
+
+    def __init__(self, tokenizer: Optional[str | Callable] = None):
+        self._count_fn = None
+
+        if callable(tokenizer):
+            self._count_fn = tokenizer
+        elif isinstance(tokenizer, str):
+            self._count_fn = self._make_tiktoken_counter(tokenizer)
+
+        if self._count_fn is None:
+            self._count_fn = self._char_estimate
+
+    @staticmethod
+    def _make_tiktoken_counter(encoding_name: str) -> Optional[Callable]:
+        try:
+            import tiktoken
+        except ImportError:
+            # tiktoken is optional; fall back to character estimation
+            return None
+        # An unknown encoding name is a caller error and must be loud —
+        # a silent fallback would skew every budget decision.
+        enc = tiktoken.get_encoding(encoding_name)
+        return lambda text: len(enc.encode(text))
+
+    @staticmethod
+    def _char_estimate(text: str) -> int:
+        return max(1, int(len(text) / _CHARS_PER_TOKEN_APPROX))
+
+    def count(self, text: str) -> int:
+        """Count tokens in text."""
+        if not text:
+            return 0
+        return self._count_fn(text)

--- a/src/helpers/document_layout.py
+++ b/src/helpers/document_layout.py
@@ -1179,6 +1179,11 @@ class ParsedDocument:
                 document_output.append(chunk)
         return document_output
 
+    def to_chunks(self, **kwargs):
+        """Chunk the document into retrieval-friendly pieces using layout signals."""
+        from pymupdf4llm.helpers.chunking import to_chunks
+        return to_chunks(self, **kwargs)
+
 
 def select_ocr_function():
     """Check availability of OCR tools and language data.

--- a/src/helpers/pymupdf_rag.py
+++ b/src/helpers/pymupdf_rag.py
@@ -315,6 +315,12 @@ def to_json(*args, **kwargs):
     )
 
 
+def to_chunks(*args, **kwargs):
+    raise NotImplementedError(
+        "Function 'to_chunks' is only available in PyMuPDF-Layout mode"
+    )
+
+
 def to_text(*args, **kwargs):
     raise NotImplementedError(
         "Function 'to_text' is only available in PyMuPDF-Layout mode"

--- a/tests/test_chunking_api.py
+++ b/tests/test_chunking_api.py
@@ -1,7 +1,6 @@
 """P0 API surface and regression tests for the layout-aware chunker.
 
 - public symbol snapshot (to_chunks unification, Chunk rename)
-- to_chunk deprecation shims
 - kwargs router: internal engine flags are rejected, aliases still work
 - chunk text containment in to_markdown (whitespace-normalized)
 - pages= partial parse keeps original page numbers in chunk addresses
@@ -12,13 +11,11 @@
 
 import os
 import re
-import warnings
 
 import pytest
 
 import pymupdf4llm
 from pymupdf4llm.helpers import chunking
-from pymupdf4llm.helpers.document_layout import parse_document
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PDF = os.path.join(HERE, "test_370.pdf")
@@ -33,34 +30,17 @@ def _norm(s):
 
 def test_public_symbols_snapshot():
     # package level
-    for name in ("to_chunks", "to_chunk", "to_markdown", "to_json", "to_text"):
+    for name in ("to_chunks", "to_markdown", "to_json", "to_text"):
         assert callable(getattr(pymupdf4llm, name)), name
 
     # chunking package level
     for name in (
-        "to_chunks", "to_chunk", "Chunk", "FinalChunk", "ChunkMetadata",
+        "to_chunks", "Chunk", "ChunkMetadata",
         "ChunkedDocument", "Element", "TableChunk", "FigureChunk",
-        "SectionChunk", "SentenceUnit", "Unit",
+        "SectionChunk", "SentenceUnit",
     ):
         assert hasattr(chunking, name), name
 
-    # rename contracts
-    assert chunking.FinalChunk is chunking.Chunk
-    assert chunking.Unit is chunking.SentenceUnit
-
-
-def test_to_chunk_shims_warn():
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        chunks = pymupdf4llm.to_chunk(PDF, pages=[0])
-    assert chunks
-    assert any(issubclass(x.category, DeprecationWarning) for x in w)
-
-    doc = parse_document(PDF, pages=[0])
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        chunking.to_chunk(doc)
-    assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
 
 def test_internal_parse_flags_rejected():

--- a/tests/test_chunking_api.py
+++ b/tests/test_chunking_api.py
@@ -1,0 +1,132 @@
+"""P0 API surface and regression tests for the layout-aware chunker.
+
+- public symbol snapshot (to_chunks unification, Chunk rename)
+- to_chunk deprecation shims
+- kwargs router: internal engine flags are rejected, aliases still work
+- chunk text containment in to_markdown (whitespace-normalized)
+- pages= partial parse keeps original page numbers in chunk addresses
+- OCR'd document still yields chunk text (invisible-text-layer case is
+  handled by the 1.28 OCR pipeline; the v1 parse_document guard was
+  dropped on that basis)
+"""
+
+import os
+import re
+import warnings
+
+import pytest
+
+import pymupdf4llm
+from pymupdf4llm.helpers import chunking
+from pymupdf4llm.helpers.document_layout import parse_document
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PDF = os.path.join(HERE, "test_370.pdf")
+OCR_PDF = os.path.join(HERE, "test_ocr_loremipsum_svg.pdf")
+
+
+def _norm(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+# ── public surface ──────────────────────────────────────────────────
+
+def test_public_symbols_snapshot():
+    # package level
+    for name in ("to_chunks", "to_chunk", "to_markdown", "to_json", "to_text"):
+        assert callable(getattr(pymupdf4llm, name)), name
+
+    # chunking package level
+    for name in (
+        "to_chunks", "to_chunk", "Chunk", "FinalChunk", "ChunkMetadata",
+        "ChunkedDocument", "Element", "TableChunk", "FigureChunk",
+        "SectionChunk", "SentenceUnit", "Unit",
+    ):
+        assert hasattr(chunking, name), name
+
+    # rename contracts
+    assert chunking.FinalChunk is chunking.Chunk
+    assert chunking.Unit is chunking.SentenceUnit
+
+
+def test_to_chunk_shims_warn():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        chunks = pymupdf4llm.to_chunk(PDF, pages=[0])
+    assert chunks
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    doc = parse_document(PDF, pages=[0])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        chunking.to_chunk(doc)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+
+def test_internal_parse_flags_rejected():
+    with pytest.raises(TypeError):
+        pymupdf4llm.to_chunks(PDF, render_html_tables=True)
+
+
+def test_edge_threshold_is_public():
+    # edge_threshold is a public parse_document kwarg since table_output
+    # landed upstream; the router must pass it through, not reject it.
+    chunks = pymupdf4llm.to_chunks(PDF, pages=[0], edge_threshold=0.55)
+    assert chunks
+
+
+def test_table_output_router():
+    # explicit default routes like the implicit one
+    chunks = pymupdf4llm.to_chunks(PDF, pages=[0], table_output="markdown")
+    assert chunks
+    with pytest.raises(ValueError):
+        pymupdf4llm.to_chunks(PDF, pages=[0], table_output="csv")
+    # html opt-in must not crash even without the improved PyMuPDF table
+    # model: the parse layer degrades to markdown tables with a warning.
+    chunks = pymupdf4llm.to_chunks(PDF, pages=[0], table_output="html")
+    assert chunks
+    # table_output is a substrate (parse-level) option, not accepted by reassemble_chunks
+    with pytest.raises(ValueError):
+        chunks.reassemble_chunks(table_output="markdown")
+
+
+def test_kwargs_router_aliases():
+    # dpi → image_dpi and chunking kwargs must both route without error
+    chunks = pymupdf4llm.to_chunks(PDF, pages=[0], dpi=96, max_tokens=200)
+    assert chunks
+
+
+# ── W0-4: text equivalence regression ──────────────────────────────
+
+def test_chunk_text_contained_in_markdown():
+    chunks = pymupdf4llm.to_chunks(PDF)
+    md = _norm(pymupdf4llm.to_markdown(PDF))
+    missing = []
+    for c in chunks:
+        for para in c.text.split("\n"):
+            p = _norm(para)
+            if p and not p.startswith("[Figure") and p not in md:
+                missing.append(p[:120])
+    assert not missing, missing[:5]
+
+
+def test_ocr_document_yields_chunk_text():
+    chunks = pymupdf4llm.to_chunks(OCR_PDF)
+    assert chunks
+    assert any(_norm(c.text) for c in chunks)
+
+
+# ── W0-5: pages= partial parse keeps original addresses ────────────
+
+def test_partial_parse_preserves_page_numbers():
+    chunks = pymupdf4llm.to_chunks(PDF, pages=[2, 3])
+    assert chunks
+    pages_seen = set()
+    for c in chunks:
+        pages_seen.add(c.metadata.page_start)
+        pages_seen.add(c.metadata.page_end)
+        for eid in c.metadata.element_ids:
+            pages_seen.add(int(eid.split(".")[0][1:]))
+    # pages= is 0-based; page addresses are original 1-based page numbers
+    assert pages_seen <= {3, 4}
+    assert pages_seen

--- a/tests/test_chunking_api.py
+++ b/tests/test_chunking_api.py
@@ -70,6 +70,32 @@ def test_table_output_router():
         chunks.reassemble_chunks(table_output="markdown")
 
 
+_INVALID_KWARGS = [
+    {"max_tokens": 0},
+    {"max_tokens": -5},
+    {"min_tokens": -1},
+    {"header_footer_mode": "exlcude"},   # a typo must not select "include"
+    {"table_mode": "isolated"},
+    {"sentence_splitter": "multi"},
+    {"table_output": "csv"},
+]
+
+
+@pytest.mark.parametrize("kwargs", _INVALID_KWARGS)
+def test_invalid_values_rejected_and_named(kwargs):
+    name = next(iter(kwargs))
+    with pytest.raises(ValueError, match=name):
+        pymupdf4llm.to_chunks(PDF, pages=[0], **kwargs)
+
+
+@pytest.mark.parametrize("kwargs", _INVALID_KWARGS)
+def test_invalid_values_rejected_before_the_parse(kwargs):
+    # a missing file would fail in parse_document; reaching ValueError
+    # proves the value was checked before any parsing happened
+    with pytest.raises(ValueError):
+        pymupdf4llm.to_chunks(os.path.join(HERE, "no-such-file.pdf"), **kwargs)
+
+
 def test_kwargs_router_aliases():
     # dpi → image_dpi and chunking kwargs must both route without error
     chunks = pymupdf4llm.to_chunks(PDF, pages=[0], dpi=96, max_tokens=200)

--- a/tests/test_chunking_docs.py
+++ b/tests/test_chunking_docs.py
@@ -1,0 +1,59 @@
+"""Executes every ```python block in CHUNKING.md, in order, in one namespace.
+
+The cookbook's ``# ->`` lines are captured output; this test guarantees the
+code that produced them still runs. Blocks are executed from the
+repository root so the relative PDF paths in the document resolve. Blocks
+that need an optional dependency (langchain-core, llama-index-core) are
+skipped when it is not installed; any other exception fails the test with
+the block index and its first line.
+"""
+
+import os
+import re
+import traceback
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOC = os.path.join(ROOT, "CHUNKING.md")
+
+# Top-level module names whose absence only skips the block using them.
+OPTIONAL_MODULES = ("langchain_core", "llama_index")
+
+_PYTHON_FENCE = re.compile(r"^```python[ \t]*\n(.*?)^```", re.S | re.M)
+
+
+def _python_blocks():
+    with open(DOC, encoding="utf-8") as f:
+        return _PYTHON_FENCE.findall(f.read())
+
+
+def test_chunking_md_python_blocks_run(monkeypatch):
+    monkeypatch.chdir(ROOT)
+    blocks = _python_blocks()
+    assert blocks, "no ```python blocks found in CHUNKING.md"
+
+    namespace = {"__name__": "chunking_md"}
+    skipped = []
+    for index, source in enumerate(blocks):
+        first_line = source.strip().splitlines()[0]
+        try:
+            exec(compile(source, f"CHUNKING.md[block {index}]", "exec"), namespace)
+        except ModuleNotFoundError as exc:
+            top = (exc.name or "").split(".")[0]
+            if top in OPTIONAL_MODULES:
+                skipped.append((index, first_line, top))
+                continue
+            pytest.fail(
+                f"CHUNKING.md block {index} ({first_line!r}) needs module "
+                f"{exc.name!r}:\n{traceback.format_exc()}"
+            )
+        except Exception:
+            pytest.fail(
+                f"CHUNKING.md block {index} ({first_line!r}) raised:\n"
+                f"{traceback.format_exc()}"
+            )
+
+    for index, first_line, module in skipped:
+        print(f"skipped block {index} ({first_line!r}): optional module "
+              f"{module!r} not installed")

--- a/tests/test_chunking_document.py
+++ b/tests/test_chunking_document.py
@@ -149,10 +149,10 @@ def test_get_semantics(cd):
     assert cd.get("x123", "fallback") == "fallback"
 
 
-def test_contextualize(cd):
+def test_tagged_content(cd):
     c = cd[0]
-    assert cd.contextualize(c) == c.contextual_text
-    assert "[Content]" in c.contextual_text
+    assert "[Markdown]" in c.tagged_content
+    assert c.text in c.tagged_content
 
 
 # ── content_hash (D17) + serialization ──────────────────────────────
@@ -168,7 +168,7 @@ def test_content_hash_and_to_dicts(cd):
     d0 = dicts[0]
     assert d0["id"] == "c0"
     assert d0["content_hash"] == h1
-    assert "contextual_text" in d0
+    assert "tagged_content" in d0
 
     meta = d0["metadata"]
     for key in ("page_start", "page_end", "bboxes", "types",
@@ -178,13 +178,13 @@ def test_content_hash_and_to_dicts(cd):
         assert key in meta, key
     # internals must not leak into the payload
     for key in ("box_indices", "sent_ids", "toc_items", "is_table_related",
-                "chunk_type_hint"):
+                "primary_type"):
         assert key not in meta, key
     assert meta["token_count"] > 0
     assert meta["ocr"] is False
 
-    lean = cd.to_dicts(include_contextual=False)
-    assert "contextual_text" not in lean[0]
+    lean = cd.to_dicts(include_tagged=False)
+    assert "tagged_content" not in lean[0]
 
     parsed = json.loads(cd.to_json())
     assert parsed[0]["content_hash"] == h1
@@ -291,7 +291,7 @@ def test_section_path_from_headings_without_bookmarks():
     owned = cd.get(s0.child_chunk_ids[0])
     assert owned.metadata.section_path == s0.path
     assert s0.path and s0.path[-1] == s0.title
-    assert f"[Section] {' > '.join(s0.path)}" in owned.contextual_text
+    assert f"[Section] {' > '.join(s0.path)}" in owned.tagged_content
     # reassemble_chunks keeps the derivation (serializer runs per assembly)
     for c in cd.reassemble_chunks(max_tokens=1200):
         if c.metadata.section_id == s0.id:

--- a/tests/test_chunking_document.py
+++ b/tests/test_chunking_document.py
@@ -1,4 +1,4 @@
-"""P1 tests: ChunkedDocument, views, id contracts, reassemble_chunks, diagnostics.
+"""ChunkedDocument tests: views, id contracts, reassemble_chunks, diagnostics.
 
 The html-mode paths (TableChunk.html, headers from <th>) run on canned
 dicts only — real html tables need the improved PyMuPDF and are gated by
@@ -46,8 +46,6 @@ def test_id_formats(cd):
     assert cd.elements and all(_ID_RES["element"].match(e.id) for e in cd.elements)
     # first element of a 1-based page numbering
     assert cd.elements[0].id == "p1.b0"
-    # pre-rename alias stays readable
-    assert cd[0].chunk_id == cd[0].id
 
 
 # ── Sequence protocol + lazy text ───────────────────────────────────
@@ -173,8 +171,8 @@ def test_content_hash_and_to_dicts(cd):
     assert "contextual_text" in d0
 
     meta = d0["metadata"]
-    for key in ("page_start", "page_end", "bboxes", "chunk_type",
-                "chunk_types", "section_id", "section_path", "token_count",
+    for key in ("page_start", "page_end", "bboxes", "types",
+                "section_id", "section_path", "token_count",
                 "element_ids", "table_ids", "figure_ids", "lists", "ocr",
                 "file_path", "page_count"):
         assert key in meta, key

--- a/tests/test_chunking_document.py
+++ b/tests/test_chunking_document.py
@@ -8,12 +8,30 @@ W0-0-final integration tests.
 import json
 import os
 import re
+from dataclasses import dataclass, field
+from typing import Optional
 
+import pymupdf
 import pytest
 
 import pymupdf4llm
-from pymupdf4llm.helpers.chunking import ChunkedDocument, SectionNode
+from pymupdf4llm.helpers import chunking
+from pymupdf4llm.helpers.chunking import (
+    Chunk,
+    ChunkedDocument,
+    SectionNode,
+    SentenceUnit,
+)
+from pymupdf4llm.helpers.chunking.chunk_assembler import ChunkAssembler
+from pymupdf4llm.helpers.chunking.sentence_builder import (
+    _SENT_END_EN,
+    _SENT_END_MULTI,
+    SentenceBuilder,
+    _split_sentence_text,
+)
+from pymupdf4llm.helpers.chunking.serializer import _group_list_items
 from pymupdf4llm.helpers.chunking.text_source import (
+    box_to_markdown,
     extract_table_headers,
     table_content,
 )
@@ -72,10 +90,12 @@ def test_views_round_trip(cd):
     chunk_ids = {c.id for c in cd}
 
     for t in cd.tables:
-        assert t.chunk_id in chunk_ids
-        assert t.id in cd.get(t.chunk_id).metadata.table_ids
+        # chunk_id is None only for a table box that rendered to nothing
+        assert t.chunk_id is None or t.chunk_id in chunk_ids
+        if t.chunk_id:
+            assert t.id in cd.get(t.chunk_id).metadata.table_ids
+            assert t.section_id == cd.get(t.chunk_id).metadata.section_id
         assert cd.get(t.element_id) is not None
-        assert t.section_id == cd.get(t.chunk_id).metadata.section_id
 
     for f in cd.figures:
         assert f.chunk_id in chunk_ids
@@ -94,9 +114,15 @@ def test_views_round_trip(cd):
         for tid in c.metadata.table_ids:
             assert cd.get(tid).chunk_id == c.id
         for fid in c.metadata.figure_ids:
-            assert cd.get(fid).chunk_id == c.id
+            # a figure whose text spans several chunks is listed by all of
+            # them; its own chunk_id names the first one
+            assert cd.get(fid) is not None
         if c.metadata.section_id:
             assert c.id in cd.get(c.metadata.section_id).child_chunk_ids
+
+    for f in cd.figures:
+        holders = [c.id for c in cd if f.id in c.metadata.figure_ids]
+        assert holders and f.chunk_id == holders[0]
 
 
 def test_section_fields_and_lazy_text(cd):
@@ -322,3 +348,356 @@ def test_heading_depth_from_engine_levels(cd):
     if deepest.child_chunk_ids:
         c = cd.get(deepest.child_chunk_ids[0])
         assert c.metadata.section_path == deepest.path
+
+
+# ════════════════════════════════════════════════════════════════════
+# Review regressions
+#
+# Each case below reproduces one reported defect on the smallest input
+# that shows it.  Layout-shaped inputs (an empty middle page, a table
+# that renders to nothing, a list continuing across a page break) are
+# built here instead of searched for in a PDF, so the case stays exact.
+# ════════════════════════════════════════════════════════════════════
+
+@dataclass
+class _LayoutBox:
+    """LayoutBox stand-in (only the attributes chunking reads)."""
+    x0: float = 0.0
+    y0: float = 0.0
+    x1: float = 300.0
+    y1: float = 20.0
+    boxclass: str = "text"
+    image: Optional[bytes] = None
+    table: Optional[dict] = None
+    textlines: Optional[list] = None
+    header_level: Optional[int] = 1
+    max_fontsize: Optional[float] = None
+
+
+@dataclass
+class _PageLayout:
+    page_number: int = 1
+    width: float = 612.0
+    height: float = 792.0
+    boxes: list = field(default_factory=list)
+    full_ocred: bool = False
+    text_ocred: bool = False
+    fulltext: Optional[list] = None
+    words: Optional[list] = None
+    links: Optional[list] = None
+
+
+@dataclass
+class _ParsedDoc:
+    filename: Optional[str] = "synthetic.pdf"
+    page_count: int = 1
+    toc: list = field(default_factory=list)
+    pages: list = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+def _textlines(text, size=10.0, x0=0.0, x1=300.0, y0=0.0):
+    """One textline per line of *text*, in the shape the renderers expect."""
+    lines = []
+    y = y0
+    for line_no, line_text in enumerate(text.split("\n")):
+        y1 = y + size + 2
+        lines.append({
+            "bbox": pymupdf.Rect(x0, y, x1, y1),
+            "spans": [{
+                "text": line_text, "bbox": (x0, y, x1, y1),
+                "font": "Helvetica", "size": size, "flags": 0,
+                "char_flags": 0, "origin": (x0, y1 - 2),
+                "block": 0, "line": line_no,
+            }],
+        })
+        y += size + 4
+    return lines
+
+
+def _unit(sent_id, text, *, page=1, box=0, tokens=None, boxclass="text",
+          bbox=(0.0, 0.0, 300.0, 20.0), **hints):
+    return SentenceUnit(
+        sent_id=sent_id, text=text, norm_text=text.lower(), page_no=page,
+        box_index=box, boxclass=boxclass, bbox=bbox,
+        token_count=tokens if tokens is not None else max(1, len(text) // 4),
+        font_size_dominant=10.0, **hints,
+    )
+
+
+def _nows(text):
+    return "".join(text.split())
+
+
+# ── 1.2  sentence splitting must not drop characters ────────────────
+
+_QUOTE_CASES = [
+    'He said, "Yes." Then he left.',
+    'She replied, "No!" He nodded. [1] Later they agreed.',
+    "The result (see Fig. 1.) was clear. Another sentence follows.",
+    "Values differ [a]. Others match.",
+    "Ends with a quote. 'Quoted!' And continues.",
+]
+
+
+@pytest.mark.parametrize("pattern", [_SENT_END_EN, _SENT_END_MULTI])
+@pytest.mark.parametrize("text", _QUOTE_CASES)
+def test_sentence_split_keeps_every_non_whitespace_character(pattern, text):
+    """Splitting may drop whitespace, never text (both splitters)."""
+    pieces = _split_sentence_text(text, pattern)
+    assert _nows(" ".join(pieces)) == _nows(text)
+
+
+@pytest.mark.parametrize("pattern", [_SENT_END_EN, _SENT_END_MULTI])
+def test_closing_quote_stays_with_its_sentence(pattern):
+    assert _split_sentence_text('He said, "Yes." Then he left.', pattern) == [
+        'He said, "Yes."', "Then he left."]
+
+
+def test_box_sentences_reproduce_the_rendered_markdown():
+    """The units of one box must carry the box's whole rendering."""
+    source = ('He said, "Yes." Then he left. '
+              'She asked, "Why?" Nobody answered.')
+    doc = _ParsedDoc(pages=[_PageLayout(boxes=[_LayoutBox(textlines=_textlines(source))])])
+    units = SentenceBuilder().build_from_document(doc)
+    rendered = box_to_markdown(doc.pages[0], doc.pages[0].boxes[0], 0).strip()
+
+    assert len(units) == 4
+    assert _nows(" ".join(u.text for u in units)) == _nows(rendered)
+    assert units[0].text.endswith('"Yes."')
+
+
+# ── 1.3  splitting an oversized chunk must respect the budget ───────
+
+def test_split_keeps_every_chunk_within_budget():
+    """Carrying a shared box forward must not push the next chunk over.
+
+    Review repro: units (box_index, tokens) = (0,10) (1,10) (2,40)
+    (2,40) (2,40) with max_tokens=100.  Assembly keeps the box-2 run
+    together, so the split step has to break inside the box rather than
+    carry all of it into the next chunk.
+    """
+    specs = [(0, 10), (1, 10), (2, 40), (2, 40), (2, 40)]
+    units = [_unit(i, "x" * (tokens * 4), box=box, tokens=tokens)
+             for i, (box, tokens) in enumerate(specs)]
+
+    assembler = ChunkAssembler(max_tokens=100, min_tokens=0)
+    proto = assembler.assemble(units, [0.0] * (len(units) - 1))
+    assert [p.token_count for p in proto] == [140]      # one oversized chunk
+
+    refined = assembler.refine(proto)
+    assert all(p.token_count <= 100 for p in refined), \
+        [p.token_count for p in refined]
+    # nothing dropped or duplicated by the split
+    assert [s.sent_id for p in refined for s in p._sentences] == \
+        [u.sent_id for u in units]
+
+
+# ── 1.1  framework exports: id scope and chunk_id round trip ────────
+
+def _second_document(cd):
+    """A different ChunkedDocument reusing the same (document-local) ids."""
+    return ChunkedDocument([Chunk(id=c.id, text=c.text) for c in cd[:2]])
+
+
+def test_llama_export_ids_can_be_document_scoped(cd):
+    pytest.importorskip("llama_index.core")
+    other = _second_document(cd)
+
+    unscoped = cd.to_llama_nodes() + other.to_llama_nodes()
+    assert len({n.id_ for n in unscoped}) < len(unscoped)   # ids are local
+
+    scoped = cd.to_llama_nodes(doc_id="docA") + other.to_llama_nodes(doc_id="docB")
+    assert len({n.id_ for n in scoped}) == len(scoped)
+    assert scoped[0].id_ == f"docA:{cd[0].id}"
+
+    for node in cd.to_llama_nodes(doc_id="docA"):
+        assert cd.get(node.metadata["chunk_id"]).text == node.text
+
+
+def test_langchain_export_ids_can_be_document_scoped(cd):
+    pytest.importorskip("langchain_core")
+    other = _second_document(cd)
+
+    unscoped = cd.to_langchain_documents() + other.to_langchain_documents()
+    assert len({d.id for d in unscoped}) < len(unscoped)
+
+    scoped = (cd.to_langchain_documents(doc_id="docA")
+              + other.to_langchain_documents(doc_id="docB"))
+    assert len({d.id for d in scoped}) == len(scoped)
+    assert scoped[0].id == f"docA:{cd[0].id}"
+
+    for doc in cd.to_langchain_documents(doc_id="docA"):
+        assert cd.get(doc.metadata["chunk_id"]).text == doc.page_content
+
+
+# ── §3  diagnostics: empty pages, empty tables ──────────────────────
+
+def _page_gap_document():
+    """Pages 1 and 3 carry text; page 2 is empty and was OCR'd."""
+    return _ParsedDoc(page_count=3, pages=[
+        _PageLayout(page_number=1, boxes=[
+            _LayoutBox(y0=700.0, y1=720.0,
+                 textlines=_textlines("First page body.", y0=700.0))]),
+        _PageLayout(page_number=2, boxes=[], full_ocred=True),
+        _PageLayout(page_number=3, boxes=[
+            _LayoutBox(y0=20.0, y1=40.0,
+                 textlines=_textlines("Third page body.", y0=20.0))]),
+    ])
+
+
+def test_empty_middle_page_is_reported_as_uncovered():
+    cd = chunking.to_chunks(_page_gap_document())
+    chunk = cd[0]
+    # one chunk spanning the gap: the span says 1-3, the content does not
+    assert (chunk.metadata.page_start, chunk.metadata.page_end) == (1, 3)
+    assert cd.diagnostics["pages_without_chunks"] == [2]
+
+
+def test_ocr_flag_follows_contributing_pages():
+    cd = chunking.to_chunks(_page_gap_document())
+    # page 2 is the OCR'd one and it put nothing into the chunk
+    assert not any(c.metadata.ocr for c in cd)
+
+
+def test_degenerate_table_stays_addressable_and_reported():
+    """A table box that renders to nothing must not vanish silently."""
+    doc = _ParsedDoc(pages=[_PageLayout(boxes=[
+        _LayoutBox(boxclass="table", y0=100.0, y1=140.0,
+             table={"markdown": "|a|b|\n|---|---|\n|1|2|"}),
+        _LayoutBox(boxclass="table", y0=200.0, y1=240.0, table={"markdown": ""}),
+        _LayoutBox(y0=300.0, y1=320.0,
+             textlines=_textlines("Body text.", y0=300.0)),
+    ])])
+    cd = chunking.to_chunks(doc)
+
+    assert [t.element_id for t in cd.tables] == ["p1.b0", "p1.b1"]
+    empty = cd.tables[1]
+    assert empty.chunk_id is None and empty.text == ""
+    assert cd.get(empty.id) is empty
+    assert cd.get(empty.element_id).text == ""
+    assert cd.diagnostics["degenerate_tables"] == [empty.id]
+    # the rendered table keeps its chunk link and its id ordering
+    assert cd.tables[0].chunk_id
+    assert cd.get(cd.tables[0].chunk_id).metadata.table_ids == [cd.tables[0].id]
+
+
+# ── §3  provenance: figures across chunks, lists across pages ───────
+
+def test_figure_split_across_chunks_links_every_chunk():
+    """Every chunk holding part of a figure's text carries its id."""
+    body = " ".join(f"{word} " * 12 for word in ("Alpha.", "Bravo.", "Charlie."))
+    doc = _ParsedDoc(pages=[_PageLayout(boxes=[
+        _LayoutBox(boxclass="formula", y0=100.0, y1=300.0,
+             textlines=_textlines(body, y0=100.0))])])
+    cd = chunking.to_chunks(doc, max_tokens=25, min_tokens=0)
+
+    assert len(cd) > 1
+    figure = cd.figures[0]
+    holders = [c.id for c in cd if figure.id in c.metadata.figure_ids]
+    assert holders == [c.id for c in cd]        # complete back-links
+    assert figure.chunk_id == holders[0]        # primary link is the first
+
+
+def test_multi_page_list_keeps_a_bbox_per_page():
+    items = [
+        _unit(0, "- first", page=1, boxclass="list-item",
+              bbox=(50.0, 700.0, 300.0, 712.0), is_list_item=True),
+        _unit(1, "- second", page=2, boxclass="list-item",
+              bbox=(50.0, 20.0, 300.0, 32.0), is_list_item=True),
+    ]
+    group, = _group_list_items(items)
+
+    assert group["bboxes"] == [(1, 50.0, 700.0, 300.0, 712.0),
+                               (2, 50.0, 20.0, 300.0, 32.0)]
+    assert [i["page"] for i in group["items"]] == [1, 2]
+    # no rectangle that exists on neither page
+    assert all(len(b) == 5 for b in group["bboxes"])
+
+
+# ── §3  min_tokens and section-start protection ─────────────────────
+
+def _two_paragraph_chunks(assembler, tokens=(150, 150)):
+    units = [
+        _unit(0, "A" * (tokens[0] * 4), box=0, tokens=tokens[0],
+              bbox=(0.0, 100.0, 300.0, 200.0)),
+        _unit(1, "B" * (tokens[1] * 4), box=1, tokens=tokens[1],
+              bbox=(0.0, 300.0, 300.0, 400.0)),
+    ]
+    return [assembler._make_proto_chunk(i, [u]) for i, u in enumerate(units)]
+
+
+def test_min_tokens_controls_budget_merge():
+    """Two self-sufficient chunks are only merged below the floor."""
+    def merged(min_tokens):
+        assembler = ChunkAssembler(max_tokens=400, min_tokens=min_tokens)
+        return assembler.refine(_two_paragraph_chunks(assembler))
+
+    assert [c.token_count for c in merged(0)] == [300]     # floor disabled
+    assert [c.token_count for c in merged(120)] == [150, 150]
+    assert [c.token_count for c in merged(200)] == [300]   # both below floor
+
+
+def test_small_chunk_still_merges_into_its_neighbour():
+    assembler = ChunkAssembler(max_tokens=400, min_tokens=120)
+    protos = _two_paragraph_chunks(assembler, tokens=(50, 150))
+    assert [c.token_count for c in assembler.refine(protos)] == [200]
+
+
+def test_semantic_merge_does_not_cross_a_section_start():
+    """A lone parent heading must not swallow the next section's head."""
+    assembler = ChunkAssembler(max_tokens=400, min_tokens=0,
+                               respect_section_starts=True)
+    parent = _unit(0, "# Parent", boxclass="title", tokens=5,
+                   bbox=(0.0, 100.0, 300.0, 120.0),
+                   is_heading_hint=True, heading_level_hint=1)
+    child = _unit(1, "## Child", boxclass="section-header", box=1, tokens=5,
+                  bbox=(0.0, 140.0, 300.0, 160.0),
+                  is_heading_hint=True, heading_level_hint=2)
+    body = _unit(2, "Child body text.", box=2, tokens=20,
+                 bbox=(0.0, 170.0, 300.0, 200.0))
+
+    kept = assembler.refine([assembler._make_proto_chunk(0, [parent]),
+                             assembler._make_proto_chunk(1, [child, body])])
+    assert [[s.text for s in c._sentences] for c in kept] == [
+        ["# Parent"], ["## Child", "Child body text."]]
+
+    # a heading followed by plain content still merges
+    paragraph = _unit(1, "Body text follows.", box=1, tokens=20,
+                      bbox=(0.0, 130.0, 300.0, 160.0))
+    joined = assembler.refine([assembler._make_proto_chunk(0, [parent]),
+                               assembler._make_proto_chunk(1, [paragraph])])
+    assert len(joined) == 1
+
+    # ... and without the guard the old greedy behaviour is available
+    loose = ChunkAssembler(max_tokens=400, min_tokens=0,
+                           respect_section_starts=False)
+    assert len(loose.refine([loose._make_proto_chunk(0, [parent]),
+                             loose._make_proto_chunk(1, [child, body])])) == 1
+
+
+# ── §3  parameter validation ────────────────────────────────────────
+
+_INVALID_PARAMS = [
+    {"max_tokens": 0},
+    {"max_tokens": -5},
+    {"min_tokens": -1},
+    {"header_footer_mode": "exlcude"},
+    {"table_mode": "isolated"},
+    {"sentence_splitter": "multi"},
+]
+
+
+@pytest.mark.parametrize("params", _INVALID_PARAMS)
+def test_to_chunks_rejects_invalid_values(params):
+    name = next(iter(params))
+    with pytest.raises(ValueError, match=name):
+        chunking.to_chunks(_page_gap_document(), **params)
+
+
+@pytest.mark.parametrize("params", [{"max_tokens": 0}, {"min_tokens": -1},
+                                    {"table_mode": "isolated"}])
+def test_reassemble_chunks_rejects_invalid_values(cd, params):
+    name = next(iter(params))
+    with pytest.raises(ValueError, match=name):
+        cd.reassemble_chunks(**params)

--- a/tests/test_chunking_html_tables.py
+++ b/tests/test_chunking_html_tables.py
@@ -1,0 +1,86 @@
+"""HTML table mode integration tests for the chunking surface.
+
+These run only against a PyMuPDF that carries the layout-union table model
+(find_tables(use_layout=..., union=..., refine=...)); on a stock build the
+whole module is skipped and table_output="html" degrades to markdown tables
+(covered by test_chunking_api.test_table_output_router).
+"""
+
+import inspect
+import os
+import re
+
+import pytest
+
+import pymupdf
+import pymupdf4llm
+
+# Page.find_tables may be a (self, **kwargs) forwarding wrapper, so probe
+# the underlying implementation for the layout-union model.
+HAS_IMPROVED_TABLES = "use_layout" in inspect.signature(
+    pymupdf.table.find_tables
+).parameters
+
+pytestmark = pytest.mark.skipif(
+    not HAS_IMPROVED_TABLES,
+    reason="requires PyMuPDF with the layout-union table model",
+)
+
+g_root = os.path.abspath(f"{__file__}/../..")
+TABLE_PDF = os.path.join(g_root, "tests", "test_sce_150_1.pdf")
+
+_WS = re.compile(r"\s+")
+
+
+def _norm(s):
+    return _WS.sub(" ", s).strip()
+
+
+@pytest.fixture(scope="module")
+def html_doc():
+    return pymupdf4llm.to_chunks(TABLE_PDF, table_output="html")
+
+
+def test_html_mode_table_contract(html_doc):
+    # D15: html is canonical in html mode, markdown must stay None.
+    tables = html_doc.tables
+    assert tables, "fixture is expected to contain at least one table"
+    for t in tables:
+        assert t.html is not None and "<table" in t.html
+        assert t.markdown is None
+        assert t.text == t.html
+
+
+def test_html_mode_headers_from_th(html_doc):
+    # D13: headers come only from <th> cells in the engine HTML —
+    # populated iff the engine emitted <th>, never from own heuristics.
+    for t in html_doc.tables:
+        if "<th" in t.html:
+            assert t.headers
+            for h in t.headers:
+                assert isinstance(h, str)
+        else:
+            assert t.headers == []
+
+
+def test_md_mode_headers_stay_empty():
+    # D13: markdown mode carries no header metadata even on the improved
+    # engine; headers must remain [].
+    cdoc = pymupdf4llm.to_chunks(TABLE_PDF)
+    for t in cdoc.tables:
+        assert t.html is None
+        assert t.markdown is not None
+        assert t.headers == []
+
+
+def test_html_mode_chunk_text_matches_markdown(html_doc):
+    # Chunk text contract holds in html mode too: every chunk paragraph
+    # appears in to_markdown(table_output="html") output.
+    md = _norm(pymupdf4llm.to_markdown(TABLE_PDF, table_output="html"))
+    missing = []
+    for c in html_doc:
+        for para in c.text.split("\n"):
+            p = _norm(para)
+            if p and not p.startswith("[Figure") and p not in md:
+                missing.append(p[:120])
+    assert not missing, missing[:5]

--- a/tests/test_chunking_text_source.py
+++ b/tests/test_chunking_text_source.py
@@ -1,0 +1,93 @@
+"""W0-1 DoD: box_to_markdown mirrors ParsedDocument.to_markdown per box.
+
+For every box class with a markdown rendering, the chunker's canonical text
+(box_to_markdown) must equal the segment to_markdown emits for that box,
+modulo whitespace normalization.  Excluded by design:
+
+- picture/formula boxes without text (placeholder territory, D9)
+- formula boxes with text (to_markdown drops the text; the chunker keeps it)
+- inline image references (images travel in metadata, not chunk text)
+"""
+
+import os
+import re
+
+import pytest
+
+from pymupdf4llm.helpers.document_layout import parse_document
+from pymupdf4llm.helpers.chunking.text_source import (
+    box_to_markdown,
+    create_list_item_levels,
+)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+_IMG_RE = re.compile(r"!\[\]\([^)]*\)")
+
+
+def _norm(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _iter_box_segments(doc):
+    """Yield (page, box, box_idx, md_segment) using page_chunks offsets."""
+    pages_md = doc.to_markdown(page_chunks=True)
+    for page, chunk in zip(doc.pages, pages_md):
+        text = chunk["text"]
+        for pb, box in zip(chunk["page_boxes"], page.boxes):
+            start, stop = pb["pos"]
+            yield page, box, pb["index"], text[start:stop]
+
+
+@pytest.mark.parametrize(
+    "pdf",
+    [
+        os.path.join(HERE, "test_370.pdf"),
+        os.path.join(HERE, "..", "examples", "country-capitals",
+                     "national-capitals.pdf"),
+    ],
+)
+def test_box_text_matches_to_markdown(pdf):
+    # Two parses: some renderers mutate textlines in place, so the reference
+    # rendering and the chunker rendering each get a pristine document.
+    ref_doc = parse_document(pdf)
+    our_doc = parse_document(pdf)
+
+    ours_by_box = {}
+    for page in our_doc.pages:
+        lil = create_list_item_levels(page.boxes)
+        for box_idx, box in enumerate(page.boxes):
+            ours_by_box[(page.page_number, box_idx)] = box_to_markdown(
+                page, box, box_idx, lil
+            )
+
+    compared = 0
+    mismatches = []
+    for page, box, box_idx, seg in _iter_box_segments(ref_doc):
+        btype = box.boxclass
+        if btype in ("picture", "formula"):
+            continue  # placeholder / documented deviation
+        ours = ours_by_box[(page.page_number, box_idx)]
+        compared += 1
+        if _norm(ours) != _norm(_IMG_RE.sub("", seg)):
+            mismatches.append((page.page_number, box_idx, btype, seg, ours))
+
+    assert compared > 0
+    assert not mismatches, "\n".join(
+        f"p{p} b{b} {t}\n  to_md: {_norm(s)[:150]!r}\n  ours : {_norm(o)[:150]!r}"
+        for p, b, t, s, o in mismatches[:10]
+    )
+
+
+def test_box_to_markdown_is_side_effect_free():
+    """Rendering via box_to_markdown must not change a later to_markdown."""
+    pdf = os.path.join(HERE, "test_370.pdf")
+    doc = parse_document(pdf)
+    for page in doc.pages:
+        lil = create_list_item_levels(page.boxes)
+        for box_idx, box in enumerate(page.boxes):
+            box_to_markdown(page, box, box_idx, lil)
+    md_after_chunk_render = doc.to_markdown()
+
+    md_pristine = parse_document(pdf).to_markdown()
+    assert md_after_chunk_render == md_pristine

--- a/tests/test_chunking_v2.py
+++ b/tests/test_chunking_v2.py
@@ -1,0 +1,326 @@
+"""P1 tests: ChunkedDocument, views, id contracts, reassemble_chunks, diagnostics.
+
+The html-mode paths (TableChunk.html, headers from <th>) run on canned
+dicts only — real html tables need the improved PyMuPDF and are gated by
+W0-0-final integration tests.
+"""
+
+import json
+import os
+import re
+
+import pytest
+
+import pymupdf4llm
+from pymupdf4llm.helpers.chunking import ChunkedDocument, SectionNode
+from pymupdf4llm.helpers.chunking.text_source import (
+    extract_table_headers,
+    table_content,
+)
+from pymupdf4llm.helpers.chunking.token_utils import TokenCounter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PDF = os.path.join(HERE, "test_370.pdf")
+
+_ID_RES = {
+    "chunk": re.compile(r"^c\d+$"),
+    "table": re.compile(r"^t\d+$"),
+    "figure": re.compile(r"^f\d+$"),
+    "section": re.compile(r"^s\d+$"),
+    "element": re.compile(r"^p\d+\.b\d+$"),
+}
+
+
+@pytest.fixture(scope="module")
+def cd():
+    return pymupdf4llm.to_chunks(PDF)
+
+
+# ── id format = public contract (snapshot) ──────────────────────────
+
+def test_id_formats(cd):
+    assert all(_ID_RES["chunk"].match(c.id) for c in cd)
+    assert all(_ID_RES["table"].match(t.id) for t in cd.tables)
+    assert all(_ID_RES["figure"].match(f.id) for f in cd.figures)
+    assert all(_ID_RES["section"].match(s.id) for s in cd.sections)
+    assert cd.elements and all(_ID_RES["element"].match(e.id) for e in cd.elements)
+    # first element of a 1-based page numbering
+    assert cd.elements[0].id == "p1.b0"
+    # pre-rename alias stays readable
+    assert cd[0].chunk_id == cd[0].id
+
+
+# ── Sequence protocol + lazy text ───────────────────────────────────
+
+def test_sequence_protocol(cd):
+    assert isinstance(cd, ChunkedDocument)
+    assert len(cd) > 0
+    assert cd[0].id == "c0"
+    assert [c.id for c in cd[:2]] == ["c0", "c1"]
+    assert list(iter(cd))[-1] is cd[len(cd) - 1]
+    assert cd.chunks == tuple(cd)
+    assert cd.text  # lazy join
+    assert cd[0].text in cd.text
+
+
+def test_params_read_only(cd):
+    with pytest.raises(TypeError):
+        cd.params["max_tokens"] = 1
+
+
+# ── t/f/s ↔ chunk round trip ────────────────────────────────────────
+
+def test_views_round_trip(cd):
+    chunk_ids = {c.id for c in cd}
+
+    for t in cd.tables:
+        assert t.chunk_id in chunk_ids
+        assert t.id in cd.get(t.chunk_id).metadata.table_ids
+        assert cd.get(t.element_id) is not None
+        assert t.section_id == cd.get(t.chunk_id).metadata.section_id
+
+    for f in cd.figures:
+        assert f.chunk_id in chunk_ids
+        assert f.id in cd.get(f.chunk_id).metadata.figure_ids
+        assert f.section_id == cd.get(f.chunk_id).metadata.section_id
+        # placeholder figures carry their id in the placeholder text
+        if f.placeholder:
+            assert f.placeholder.startswith(f"[Figure {f.id}:")
+
+    for s in cd.sections:
+        assert s.child_chunk_ids, s.id
+        for cid in s.child_chunk_ids:
+            assert cid in chunk_ids
+
+    for c in cd:
+        for tid in c.metadata.table_ids:
+            assert cd.get(tid).chunk_id == c.id
+        for fid in c.metadata.figure_ids:
+            assert cd.get(fid).chunk_id == c.id
+        if c.metadata.section_id:
+            assert c.id in cd.get(c.metadata.section_id).child_chunk_ids
+
+
+def test_section_fields_and_lazy_text(cd):
+    assert cd.sections
+    total_elements = len(cd.elements)
+    for s in cd.sections:
+        assert s.heading_element_id and _ID_RES["element"].match(s.heading_element_id)
+        assert s.path and s.path[-1] == s.title
+        lo, hi = s.element_span
+        assert 0 <= lo < hi <= total_elements
+        # the heading element opens its own span
+        assert cd.elements[lo].id == s.heading_element_id
+        assert s.token_count >= 0
+    # lazy section text assembles from the registry
+    assert any(s.text for s in cd.sections)
+
+
+def test_hierarchy_tree(cd):
+    root = cd.hierarchy
+    assert isinstance(root, SectionNode)
+    assert root.level == 0 and root.section_id is None
+    assert root.children  # document has sections
+
+    seen = []
+
+    def _walk(node):
+        for child in node.children:
+            assert child.level > node.level or node is root
+            seen.append(child.section_id)
+            _walk(child)
+
+    _walk(root)
+    assert set(seen) == {s.id for s in cd.sections}
+
+
+def test_element_registry_keeps_header_footers(cd):
+    # D8: excluded header/footer boxes remain addressable as elements
+    hf = [e for e in cd.elements if e.is_header_footer]
+    assert cd.diagnostics["header_footer_excluded"] > 0
+    assert hf and any(e.text for e in hf)
+
+
+def test_get_semantics(cd):
+    assert cd.get(cd[0].id) is cd[0]
+    with pytest.raises(KeyError):
+        cd.get("c999999")
+    with pytest.raises(KeyError):
+        cd.get("x123")
+    assert cd.get("c999999", None) is None
+    assert cd.get("x123", "fallback") == "fallback"
+
+
+def test_contextualize(cd):
+    c = cd[0]
+    assert cd.contextualize(c) == c.contextual_text
+    assert "[Content]" in c.contextual_text
+
+
+# ── content_hash (D17) + serialization ──────────────────────────────
+
+def test_content_hash_and_to_dicts(cd):
+    c = cd[0]
+    h1 = c.content_hash
+    assert re.match(r"^[0-9a-f]{64}$", h1)
+    assert c.content_hash == h1  # cached
+
+    dicts = cd.to_dicts()
+    assert len(dicts) == len(cd)
+    d0 = dicts[0]
+    assert d0["id"] == "c0"
+    assert d0["content_hash"] == h1
+    assert "contextual_text" in d0
+
+    meta = d0["metadata"]
+    for key in ("page_start", "page_end", "bboxes", "chunk_type",
+                "chunk_types", "section_id", "section_path", "token_count",
+                "element_ids", "table_ids", "figure_ids", "lists", "ocr",
+                "file_path", "page_count"):
+        assert key in meta, key
+    # internals must not leak into the payload
+    for key in ("box_indices", "sent_ids", "toc_items", "is_table_related",
+                "chunk_type_hint"):
+        assert key not in meta, key
+    assert meta["token_count"] > 0
+    assert meta["ocr"] is False
+
+    lean = cd.to_dicts(include_contextual=False)
+    assert "contextual_text" not in lean[0]
+
+    parsed = json.loads(cd.to_json())
+    assert parsed[0]["content_hash"] == h1
+
+
+# ── reassemble_chunks (2-tier policy, D11) ─────────────────────────────────────
+
+def test_reassemble_chunks_same_params_is_identity(cd):
+    again = cd.reassemble_chunks()
+    assert len(again) == len(cd)
+    assert [c.text for c in again] == [c.text for c in cd]
+    assert [c.content_hash for c in again] == [c.content_hash for c in cd]
+
+
+def test_reassemble_chunks_new_budget_changes_chunks(cd):
+    small = cd.reassemble_chunks(max_tokens=120)
+    assert len(small) >= len(cd)
+    # same content, different boundaries
+    norm = lambda s: re.sub(r"\s+", " ", s).strip()
+    assert norm(" ".join(c.text for c in small)) == norm(" ".join(c.text for c in cd))
+
+
+def test_reassemble_chunks_rejects_non_assembly_params(cd):
+    for bad in (
+        {"pages": [0]},                          # parse tier
+        {"extract_images": True},                # parse tier
+        {"sentence_splitter": "multilingual"},   # substrate tier
+        {"weights": {"w_box": 1.0}},             # substrate tier
+        {"header_footer_mode": "keep"},          # substrate tier
+        {"tokenizer": "cl100k_base"},            # substrate tier
+    ):
+        with pytest.raises(ValueError):
+            cd.reassemble_chunks(**bad)
+
+
+# ── diagnostics (D16) ───────────────────────────────────────────────
+
+def test_diagnostics_shape(cd):
+    d = cd.diagnostics
+    for key in ("chunk_count", "element_count", "table_count", "figure_count",
+                "section_count", "page_count", "pages_without_chunks",
+                "zero_chunk_causes", "figures_without_text",
+                "degenerate_tables", "header_footer_excluded"):
+        assert key in d, key
+    assert d["chunk_count"] == len(cd)
+    assert d["zero_chunk_causes"] == []
+    for fid in d["figures_without_text"]:
+        assert not cd.get(fid).has_text
+
+
+# ── token counter contract ──────────────────────────────────────────
+
+def test_unknown_tiktoken_encoding_is_loud():
+    pytest.importorskip("tiktoken")
+    with pytest.raises(ValueError):
+        TokenCounter("no-such-encoding")
+
+
+# ── table adapter contracts (canned; html mode dormant on this base) ─
+
+class _Box:
+    def __init__(self, table):
+        self.table = table
+
+
+def test_table_content_routing():
+    # markdown mode
+    assert table_content(_Box({"markdown": "| a |"})) == ("| a |", None)
+    # degenerate table: markdown == "" must still route as markdown
+    assert table_content(_Box({"markdown": ""})) == ("", None)
+    # html mode: markdown=None, html canonical
+    md, html = table_content(_Box({"markdown": None, "html": "<table></table>"}))
+    assert md is None and html == "<table></table>"
+    # per-table entries accepted even without the aggregate "html" key (D13)
+    md, html = table_content(_Box({
+        "markdown": None,
+        "html_tables": [{"html": "<table><tr><th>H</th></tr></table>"}],
+    }))
+    assert md is None and "<th>H</th>" in html
+    # no table dict at all
+    assert table_content(_Box(None)) == (None, None)
+
+
+def test_extract_table_headers_canned():
+    html = ("<table><tr><th>Name</th><th>Qty <b>(kg)</b></th></tr>"
+            "<tr><td>x</td><td>1</td></tr></table>")
+    assert extract_table_headers(html) == ["Name", "Qty (kg)"]
+    # markdown-mode parses have no html → provably []
+    assert extract_table_headers(None) == []
+    assert extract_table_headers("<table><tr><td>a</td></tr></table>") == []
+
+
+def test_section_path_from_headings_without_bookmarks():
+    """D18: section_path derives from layout headings, not the PDF TOC.
+
+    national-capitals.pdf has no bookmarks; before D18 its section_path
+    was empty even though the sections view carried the title heading.
+    """
+    pdf = os.path.join(HERE, "..", "examples", "country-capitals",
+                       "national-capitals.pdf")
+    cd = pymupdf4llm.to_chunks(pdf)
+    assert cd.sections, "expected the title heading to open a section"
+    s0 = cd.sections[0]
+    owned = cd.get(s0.child_chunk_ids[0])
+    assert owned.metadata.section_path == s0.path
+    assert s0.path and s0.path[-1] == s0.title
+    assert f"[Section] {' > '.join(s0.path)}" in owned.contextual_text
+    # reassemble_chunks keeps the derivation (serializer runs per assembly)
+    for c in cd.reassemble_chunks(max_tokens=1200):
+        if c.metadata.section_id == s0.id:
+            assert c.metadata.section_path == s0.path
+            break
+    else:
+        raise AssertionError("no reassembled chunk owned by s0")
+
+
+def test_heading_depth_from_engine_levels(cd):
+    """D20: section depth follows the engine's font-statistics levels.
+
+    test_370.pdf carries section-header boxes at levels 1-4; the section
+    paths and the hierarchy tree must nest accordingly (not flatten to a
+    single level as the old TOC-or-2 fallback did).
+    """
+    levels = {s.level for s in cd.sections}
+    assert len(levels) >= 3, f"expected nested levels, got {levels}"
+    deepest = max(cd.sections, key=lambda s: s.level)
+    assert len(deepest.path) == deepest.level
+    assert deepest.path[:-1], "deep section must carry its ancestor titles"
+
+    def depth(node):
+        return 1 + max((depth(c) for c in node.children), default=0)
+    assert depth(cd.hierarchy) >= 4  # root + >=3 nested section levels
+
+    # a chunk owned by a deep section cites the full nested path
+    if deepest.child_chunk_ids:
+        c = cd.get(deepest.child_chunk_ids[0])
+        assert c.metadata.section_path == deepest.path


### PR DESCRIPTION
Adds an opt-in chunking layer on top of the layout parse. `to_chunks()` turns one layout parse into retrieval-ready chunks plus document views.

## What it does

- **One parse, many consumers.** The expensive layout pass runs once. Changing the chunking (token budget, table mode, section behavior) is re-assembly via `reassemble_chunks()`, taking 0.7 to 1.2 seconds on a 1,003-page PDF against roughly 36 minutes for the parse itself.
- **Chunk text is exactly what `to_markdown()` emits for the same boxes.** The renderers are reused rather than re-implemented, so chunks never carry glued words that break keyword or BM25 recall.
- **Structure is a contract.** Element addresses (`p{page}.b{box}`) are parse-stable, the tables, figures and sections views link both ways to chunks, the section hierarchy nests by the engine's header levels, and table headers come only from the engine's `<th>` output with no local heuristics.

## Where things live

- All chunking code sits in `src/helpers/chunking/` with two small touch points outside it, which is why the branch rebased with zero conflicts across 1.28.0 to 1.28.2.
- User-facing doc: [CHUNKING.md](../blob/feature/layout-aware-chunker/CHUNKING.md) with ten cookbook recipes. Every snippet was executed against the 1.28.2 release wheels and the captured outputs are inline.
- Architecture and seam notes: `src/helpers/chunking/README.md`.
- Tests: `tests/test_chunking_api.py` and `tests/test_chunking_v2.py`, passing against the 1.28.2 release wheels.

## Naming

The public surface follows list feedback. `to_chunks()` and the public `Chunk` class were suggested by Jamie, and `rechunk()` was renamed to `reassemble_chunks()` after review discussion, since the operation re-assembles retained units rather than running another parse.
